### PR TITLE
Included nginx configure options to nginx-build.

### DIFF
--- a/configuregen.go
+++ b/configuregen.go
@@ -31,7 +31,7 @@ func configureGenModule3rd(modules3rd []Module3rd) string {
 	return result
 }
 
-func configureGen(configure string, modules3rd []Module3rd, dependencies []StaticLibrary, options ConfigureOptions) string {
+func configureGen(configure string, modules3rd []Module3rd, dependencies []StaticLibrary, options ConfigureOptions, rootDir string) string {
 	openSSLStatic := false
 	if len(configure) == 0 {
 		configure = `#!/bin/sh
@@ -59,7 +59,11 @@ func configureGen(configure string, modules3rd []Module3rd, dependencies []Stati
 
 	for _, option := range options.Values {
 		if *option.Value != "" {
-			configure += option.Name + "=" + *option.Value + " \\\n"
+			if option.Name == "--add-module" {
+				configure += normalizeAddModulePaths(*option.Value, rootDir)
+			} else {
+				configure += option.Name + "=" + *option.Value + " \\\n"
+			}
 		}
 	}
 

--- a/configuregen.go
+++ b/configuregen.go
@@ -31,7 +31,7 @@ func configureGenModule3rd(modules3rd []Module3rd) string {
 	return result
 }
 
-func configureGen(configure string, modules3rd []Module3rd, dependencies []StaticLibrary) string {
+func configureGen(configure string, modules3rd []Module3rd, dependencies []StaticLibrary, options ConfigureOptions) string {
 	openSSLStatic := false
 	if len(configure) == 0 {
 		configure = `#!/bin/sh
@@ -56,6 +56,18 @@ func configureGen(configure string, modules3rd []Module3rd, dependencies []Stati
 
 	configure_modules3rd := configureGenModule3rd(modules3rd)
 	configure += configure_modules3rd
+
+	for _, option := range options.Values {
+		if *option.Value != "" {
+			configure += option.Name + "=" + *option.Value + " \\\n"
+		}
+	}
+
+	for _, option := range options.Bools {
+		if *option.Enabled {
+			configure += option.Name + " \\\n"
+		}
+	}
 
 	return configure
 }

--- a/configuregen_test.go
+++ b/configuregen_test.go
@@ -61,7 +61,7 @@ func (suite *ConfiguregenTestSuite) TestConfiguregenModule3rd() {
 
 func (suite *ConfiguregenTestSuite) TestConfiguregenDefault() {
 	var configureOptions ConfigureOptions
-	configureScript := configureGen("", []Module3rd{}, []StaticLibrary{}, configureOptions)
+	configureScript := configureGen("", []Module3rd{}, []StaticLibrary{}, configureOptions, "")
 
 	if runtime.GOOS == "darwin" {
 		assert.Contains(suite.T(), configureScript, "--with-cc-opt=\"-Wno-deprecated-declarations\" \\")
@@ -74,7 +74,7 @@ func (suite *ConfiguregenTestSuite) TestConfiguregenWithStaticLibraries() {
 	dependencies = append(dependencies, makeStaticLibrary(&suite.builders[COMPONENT_OPENSSL]))
 	dependencies = append(dependencies, makeStaticLibrary(&suite.builders[COMPONENT_ZLIB]))
 	var configureOptions ConfigureOptions
-	configureScript := configureGen("", []Module3rd{}, dependencies, configureOptions)
+	configureScript := configureGen("", []Module3rd{}, dependencies, configureOptions, "")
 
 	assert.Contains(suite.T(), configureScript, "--with-http_ssl_module")
 	assert.Contains(suite.T(), configureScript, fmt.Sprintf("--with-pcre=../pcre-%s \\\n", PCRE_VERSION))

--- a/configuregen_test.go
+++ b/configuregen_test.go
@@ -60,7 +60,8 @@ func (suite *ConfiguregenTestSuite) TestConfiguregenModule3rd() {
 }
 
 func (suite *ConfiguregenTestSuite) TestConfiguregenDefault() {
-	configureScript := configureGen("", []Module3rd{}, []StaticLibrary{})
+	var configureOptions ConfigureOptions
+	configureScript := configureGen("", []Module3rd{}, []StaticLibrary{}, configureOptions)
 
 	if runtime.GOOS == "darwin" {
 		assert.Contains(suite.T(), configureScript, "--with-cc-opt=\"-Wno-deprecated-declarations\" \\")
@@ -72,7 +73,8 @@ func (suite *ConfiguregenTestSuite) TestConfiguregenWithStaticLibraries() {
 	dependencies = append(dependencies, makeStaticLibrary(&suite.builders[COMPONENT_PCRE]))
 	dependencies = append(dependencies, makeStaticLibrary(&suite.builders[COMPONENT_OPENSSL]))
 	dependencies = append(dependencies, makeStaticLibrary(&suite.builders[COMPONENT_ZLIB]))
-	configureScript := configureGen("", []Module3rd{}, dependencies)
+	var configureOptions ConfigureOptions
+	configureScript := configureGen("", []Module3rd{}, dependencies, configureOptions)
 
 	assert.Contains(suite.T(), configureScript, "--with-http_ssl_module")
 	assert.Contains(suite.T(), configureScript, fmt.Sprintf("--with-pcre=../pcre-%s \\\n", PCRE_VERSION))

--- a/configureopt.go
+++ b/configureopt.go
@@ -1,0 +1,139 @@
+package main
+
+type ConfigureOptions struct {
+	Values map[string]ConfigureOptionValue
+	Bools  map[string]ConfigureOptionBool
+}
+
+type ConfigureOptionValue struct {
+	Name  string
+	Desc  string
+	Value *string
+}
+
+type ConfigureOptionBool struct {
+	Name    string
+	Desc    string
+	Enabled *bool
+}
+
+func makeArgsBool() map[string]ConfigureOptionBool {
+	argsBool := make(map[string]ConfigureOptionBool)
+
+	argsBool["with-select_module"] = ConfigureOptionBool{Name: "--with-select_module", Desc: "enable select module"}
+	argsBool["without-select_module"] = ConfigureOptionBool{Name: "--without-select_module", Desc: "disable select module"}
+	argsBool["with-poll_module"] = ConfigureOptionBool{Name: "--with-poll_module", Desc: "enable poll module"}
+	argsBool["without-poll_module"] = ConfigureOptionBool{Name: "--without-poll_module", Desc: "disable poll module"}
+	argsBool["with-threads"] = ConfigureOptionBool{Name: "--with-threads", Desc: "enable thread pool support"}
+	argsBool["with-file-aio"] = ConfigureOptionBool{Name: "--with-file-aio", Desc: "enable file AIO support"}
+	argsBool["with-ipv6"] = ConfigureOptionBool{Name: "--with-ipv6", Desc: "enable IPv6 support"}
+	argsBool["with-http_ssl_module"] = ConfigureOptionBool{Name: "--with-http_ssl_module", Desc: "enable ngx_http_ssl_module"}
+	argsBool["with-http_spdy_module"] = ConfigureOptionBool{Name: "--with-http_spdy_module", Desc: "enable ngx_http_spdy_module"}
+	argsBool["with-http_realip_module"] = ConfigureOptionBool{Name: "--with-http_realip_module", Desc: "enable ngx_http_realip_module"}
+	argsBool["with-http_addition_module"] = ConfigureOptionBool{Name: "--with-http_addition_module", Desc: "enable ngx_http_addition_module"}
+	argsBool["with-http_xslt_module"] = ConfigureOptionBool{Name: "--with-http_xslt_module", Desc: "enable ngx_http_xslt_module"}
+	argsBool["with-http_image_filter_module"] = ConfigureOptionBool{Name: "--with-http_image_filter_module", Desc: "enable ngx_http_image_filter_module"}
+	argsBool["with-http_geoip_module"] = ConfigureOptionBool{Name: "--with-http_geoip_module", Desc: "enable ngx_http_geoip_module"}
+	argsBool["with-http_sub_module"] = ConfigureOptionBool{Name: "--with-http_sub_module", Desc: "enable ngx_http_sub_module"}
+	argsBool["with-http_dav_module"] = ConfigureOptionBool{Name: "--with-http_dav_module", Desc: "enable ngx_http_dav_module"}
+	argsBool["with-http_flv_module"] = ConfigureOptionBool{Name: "--with-http_flv_module", Desc: "enable ngx_http_flv_module"}
+	argsBool["with-http_mp4_module"] = ConfigureOptionBool{Name: "--with-http_mp4_module", Desc: "enable ngx_http_mp4_module"}
+	argsBool["with-http_gunzip_module"] = ConfigureOptionBool{Name: "--with-http_gunzip_module", Desc: "enable ngx_http_gunzip_module"}
+	argsBool["with-http_gzip_static_module"] = ConfigureOptionBool{Name: "--with-http_gzip_static_module", Desc: "enable ngx_http_gzip_static_module"}
+	argsBool["with-http_auth_request_module"] = ConfigureOptionBool{Name: "--with-http_auth_request_module", Desc: "enable ngx_http_auth_request_module"}
+	argsBool["with-http_random_index_module"] = ConfigureOptionBool{Name: "--with-http_random_index_module", Desc: "enable ngx_http_random_index_module"}
+	argsBool["with-http_secure_link_module"] = ConfigureOptionBool{Name: "--with-http_secure_link_module", Desc: "enable ngx_http_secure_link_module"}
+	argsBool["with-http_degradation_module"] = ConfigureOptionBool{Name: "--with-http_degradation_module", Desc: "enable ngx_http_degradation_module"}
+	argsBool["with-http_stub_status_module"] = ConfigureOptionBool{Name: "--with-http_stub_status_module", Desc: "enable ngx_http_stub_status_module"}
+	argsBool["without-http_charset_module"] = ConfigureOptionBool{Name: "--with-http_charset_module", Desc: "disable ngx_http_charset_module"}
+	argsBool["without-http_gzip_module"] = ConfigureOptionBool{Name: "--with-http_gzip_module", Desc: "disable ngx_http_gzip_module"}
+	argsBool["without-http_ssi_module"] = ConfigureOptionBool{Name: "--with-http_ssi_module", Desc: "disable ngx_http_ssi_module"}
+	argsBool["without-http_userid_module"] = ConfigureOptionBool{Name: "--with-http_userid_module", Desc: "disable ngx_http_userid_module"}
+	argsBool["without-http_access_module"] = ConfigureOptionBool{Name: "--with-http_access_module", Desc: "disable ngx_http_access_module"}
+	argsBool["without-http_auth_basic_module"] = ConfigureOptionBool{Name: "--with-http_auth_basic_module", Desc: "disable ngx_http_auth_basic_module"}
+	argsBool["without-http_autoindex_module"] = ConfigureOptionBool{Name: "--with-http_autoindex_module", Desc: "disable ngx_http_autoindex_module"}
+	argsBool["without-http_geo_module"] = ConfigureOptionBool{Name: "--with-http_geo_module", Desc: "disable ngx_http_geo_module"}
+	argsBool["without-http_map_module"] = ConfigureOptionBool{Name: "--with-http_map_module", Desc: "disable ngx_http_map_module"}
+	argsBool["without-http_split_clients_module"] = ConfigureOptionBool{Name: "--with-http_split_clients_module", Desc: "disable ngx_http_split_clients_module"}
+	argsBool["without-http_referer_module"] = ConfigureOptionBool{Name: "--with-http_referer_module", Desc: "disable ngx_http_referer_module"}
+	argsBool["without-http_rewrite_module"] = ConfigureOptionBool{Name: "--with-http_rewrite_module", Desc: "disable ngx_http_rewrite_module"}
+	argsBool["without-http_proxy_module"] = ConfigureOptionBool{Name: "--with-http_proxy_module", Desc: "disable ngx_http_proxy_module"}
+	argsBool["without-http_fastcgi_module"] = ConfigureOptionBool{Name: "--with-http_fastcgi_module", Desc: "disable ngx_http_fastcgi_module"}
+	argsBool["without-http_uwsgi_module"] = ConfigureOptionBool{Name: "--with-http_uwsgi_module", Desc: "disable ngx_http_uwsgi_module"}
+	argsBool["without-http_scgi_module"] = ConfigureOptionBool{Name: "--with-http_scgi_module", Desc: "disable ngx_http_scgi_module"}
+	argsBool["without-http_memcached_module"] = ConfigureOptionBool{Name: "--with-http_memcached_module", Desc: "disable ngx_http_memcached_module"}
+	argsBool["without-http_limit_conn_module"] = ConfigureOptionBool{Name: "--with-http_limit_conn_module", Desc: "disable ngx_http_limit_conn_module"}
+	argsBool["without-http_limit_req_module"] = ConfigureOptionBool{Name: "--with-http_limit_req_module", Desc: "disable ngx_http_limit_req_module"}
+	argsBool["without-http_empty_gif_module"] = ConfigureOptionBool{Name: "--with-http_empty_gif_module", Desc: "disable ngx_http_empty_gif_module"}
+	argsBool["without-http_browser_module"] = ConfigureOptionBool{Name: "--with-http_browser_module", Desc: "disable ngx_http_browser_module"}
+	argsBool["without-http_upstream_hash_module"] = ConfigureOptionBool{Name: "--with-http_upstream_hash_module", Desc: "disable ngx_http_upstream_hash_module"}
+	argsBool["without-http_upstream_ip_hash_module"] = ConfigureOptionBool{Name: "--with-http_upstream_ip_hash_module", Desc: "disable ngx_http_upstream_ip_hash_module"}
+	argsBool["without-http_upstream_least_conn_module"] = ConfigureOptionBool{Name: "--with-http_upstream_least_conn_module", Desc: "disable ngx_http_upstream_least_conn_module"}
+	argsBool["without-http_upstream_keepalive_module"] = ConfigureOptionBool{Name: "--with-http_upstream_keepalive_module", Desc: "disable ngx_http_upstream_keepalive_module"}
+	argsBool["without-http_upstream_zone_module"] = ConfigureOptionBool{Name: "--with-http_upstream_zone_module", Desc: "disable ngx_http_upstream_zone_module"}
+	argsBool["with-http_perl_module"] = ConfigureOptionBool{Name: "--with-http_perl_module", Desc: "enable ngx_http_perl_module"}
+	argsBool["without-http"] = ConfigureOptionBool{Name: "--without-http", Desc: "disable HTTP server"}
+	argsBool["without-http-cache"] = ConfigureOptionBool{Name: "--without-http-cache", Desc: "disable HTTP cache"}
+	argsBool["with-mail"] = ConfigureOptionBool{Name: "--with-mail", Desc: "enable POP3/IMAP4/SMTP proxy module"}
+	argsBool["with-mail_ssl_module"] = ConfigureOptionBool{Name: "--with-mail_ssl_module", Desc: "enable ngx_mail_ssl_module"}
+	argsBool["without-mail_pop3_module"] = ConfigureOptionBool{Name: "--without-mail_pop3_module", Desc: "disable ngx_mail_pop3_module"}
+	argsBool["without-mail_imap_module"] = ConfigureOptionBool{Name: "--without-mail_imap_module", Desc: "disable ngx_mail_imap_module"}
+	argsBool["without-mail_smtp_module"] = ConfigureOptionBool{Name: "--without-mail_smtp_module", Desc: "disable ngx_mail_smtp_module"}
+	argsBool["with-stream"] = ConfigureOptionBool{Name: "--with-stream", Desc: "enable TCP proxy module"}
+	argsBool["with-stream_ssl_module"] = ConfigureOptionBool{Name: "--with-stream_ssl_module", Desc: "enable ngx_stream_ssl_module"}
+	argsBool["without-stream_upstream_hash_module"] = ConfigureOptionBool{Name: "--without-stream_upstream_hash_module", Desc: "disable ngx_stream_upstream_hash_module"}
+	argsBool["without-stream_upstream_least_conn_module"] = ConfigureOptionBool{Name: "--without-stream_upstream_least_conn_module", Desc: "disable ngx_stream_upstream_least_conn_module"}
+	argsBool["without-stream_upstream_zone_module"] = ConfigureOptionBool{Name: "--without-stream_upstream_zone_module", Desc: "disable ngx_stream_upstream_zone_module"}
+	argsBool["with-google_perftools_module"] = ConfigureOptionBool{Name: "--with-google_perftools_module", Desc: "enable ngx_google_perftools_module"}
+	argsBool["with-cpp_test_module"] = ConfigureOptionBool{Name: "--with-cpp_test_module", Desc: "enable ngx_cpp_test_module"}
+	argsBool["without-pcre"] = ConfigureOptionBool{Name: "--without-pcre", Desc: "disable PCRE library usage"}
+	argsBool["with-pcre-jit"] = ConfigureOptionBool{Name: "--with-pcre-jit", Desc: "build PCRE with JIT compilation support"}
+	argsBool["with-md5-asm"] = ConfigureOptionBool{Name: "--with-md5-asm", Desc: "use md5 assembler sources"}
+	argsBool["with-sha1-asm"] = ConfigureOptionBool{Name: "--with-sha1-asm", Desc: "use sha1 assembler sources"}
+	argsBool["with-debug"] = ConfigureOptionBool{Name: "--with-debug", Desc: "enable debug logging"}
+
+	return argsBool
+}
+
+func makeArgsString() map[string]ConfigureOptionValue {
+	argsString := make(map[string]ConfigureOptionValue)
+
+	argsString["prefix"] = ConfigureOptionValue{Name: "--prefix", Desc: "set installation prefix"}
+	argsString["sbin-path"] = ConfigureOptionValue{Name: "--sbin-path", Desc: "set nginx binary pathname"}
+	argsString["conf-path"] = ConfigureOptionValue{Name: "--conf-path", Desc: "set ginx.conf pathname"}
+	argsString["error-log-path"] = ConfigureOptionValue{Name: "--error-log-path", Desc: "set error log pathname"}
+	argsString["pid-path"] = ConfigureOptionValue{Name: "--pid-path", Desc: "set nginx.pid pathname"}
+	argsString["lock-path"] = ConfigureOptionValue{Name: "--lock-path", Desc: "set nginx.lock pathname"}
+	argsString["user"] = ConfigureOptionValue{Name: "--user", Desc: "set non-privileged user for worker processes"}
+	argsString["group"] = ConfigureOptionValue{Name: "--group", Desc: "set non-privileged group for worker processes"}
+	argsString["build"] = ConfigureOptionValue{Name: "--build", Desc: "set build name"}
+	argsString["builddir"] = ConfigureOptionValue{Name: "--builddir", Desc: "set build directory"}
+	argsString["with-perl_modules_path="] = ConfigureOptionValue{Name: "--with-perl_modules_path", Desc: "set Perl modules path"}
+	argsString["with-perl"] = ConfigureOptionValue{Name: "--with-perl", Desc: "set perl binary pathname"}
+	argsString["http-log-path"] = ConfigureOptionValue{Name: "--http-log-path", Desc: "set http access log pathname"}
+	argsString["http-client-body-temp-path"] = ConfigureOptionValue{Name: "--http-client-body-temp-path", Desc: "set path to store http client request body temporary files"}
+	argsString["http-proxy-temp-path"] = ConfigureOptionValue{Name: "--http-proxy-temp-path", Desc: "set path to store http proxy temporary files"}
+	argsString["http-fastcgi-temp-path"] = ConfigureOptionValue{Name: "--http-fastcgi-temp-path", Desc: "set path to store http fastcgi temporary files"}
+	argsString["http-uwsgi-temp-path"] = ConfigureOptionValue{Name: "--http-uwsgi-temp-path", Desc: "set path to store http uwsgi temporary files"}
+	argsString["http-scgi-temp-path"] = ConfigureOptionValue{Name: "--http-scgi-temp-path", Desc: "set path to store http scgi temporary files"}
+	argsString["add-module"] = ConfigureOptionValue{Name: "--add-module", Desc: "enable an external module"}
+	argsString["with-cc"] = ConfigureOptionValue{Name: "--with-cc", Desc: "set C compiler pathname"}
+	argsString["with-cpp"] = ConfigureOptionValue{Name: "--with-cpp", Desc: "set c preprocessor pathname"}
+	argsString["with-cc-opt"] = ConfigureOptionValue{Name: "--with-cc-opt", Desc: "set additional C compiler options"}
+	argsString["with-ld-opt"] = ConfigureOptionValue{Name: "--with-ld-opt", Desc: "set additional linker options"}
+	argsString["with-cpu-opt"] = ConfigureOptionValue{Name: "--with-cpu-opt", Desc: "build for the specified CPU, valid values: pentium, pentiumpro, pentium3, pentium4, athlon, opteron, sparc32, sparc64, ppc64"}
+	argsString["with-pcre"] = ConfigureOptionValue{Name: "--with-pcre", Desc: "set path to PCRE library sources"}
+	argsString["with-pcre-opt"] = ConfigureOptionValue{Name: "--with-pcre-opt", Desc: "set additional build options for PCRE"}
+	argsString["with-md5"] = ConfigureOptionValue{Name: "--with-md5", Desc: "set path to md5 library sources"}
+	argsString["with-md5-opt"] = ConfigureOptionValue{Name: "--with-md5-opt", Desc: "set additional build options for md5"}
+	argsString["with-sha1"] = ConfigureOptionValue{Name: "--with-sha1", Desc: "set path to sha1 library sources"}
+	argsString["with-sha1-opt"] = ConfigureOptionValue{Name: "--with-sha1-opt", Desc: "set additional build options for sha1"}
+	argsString["with-zlib"] = ConfigureOptionValue{Name: "--with-zlib", Desc: "set path to zlib library sources"}
+	argsString["with-zlib-opt"] = ConfigureOptionValue{Name: "--with-zlib-opt", Desc: "set additional build options for zlib"}
+	argsString["with-zlib-asm"] = ConfigureOptionValue{Name: "--with-zlib-asm", Desc: "use zlib assembler sources optimized for the specified CPU, valid values: pentium, pentiumpro"}
+	argsString["with-libatomic"] = ConfigureOptionValue{Name: "--with-libatomic", Desc: "set path to libatomic_ops library sources"}
+	argsString["with-openssl"] = ConfigureOptionValue{Name: "--with-openssl", Desc: "set path to OpenSSL library sources"}
+	argsString["with-openssl-opt"] = ConfigureOptionValue{Name: "--with-openssl-opt", Desc: "set additional build options for OpenSSL"}
+
+	return argsString
+}

--- a/nginx-build.go
+++ b/nginx-build.go
@@ -217,7 +217,7 @@ func main() {
 		log.Println("[warn]Using '--add-module' is discouraged. Instead give ini-file with '-m' to 'nginx-build'")
 	}
 
-	configureScript := configureGen(nginxConfigure, modules3rd, dependencies, configureOptions)
+	configureScript := configureGen(nginxConfigure, modules3rd, dependencies, configureOptions, rootDir)
 	err = ioutil.WriteFile("./nginx-configure", []byte(configureScript), 0655)
 	if err != nil {
 		log.Fatalf("Failed to generate configure script for %s", nginxBuilder.sourcePath())

--- a/nginx-build.go
+++ b/nginx-build.go
@@ -40,7 +40,25 @@ func main() {
 	openRestyVersion := flag.String("openrestyversion", OPENRESTY_VERSION, "openresty version")
 	tengineVersion := flag.String("tengineversion", TENGINE_VERSION, "tengine version")
 	configureOnly := flag.Bool("configureonly", false, "configuring nginx only not building")
+
+	var configureOptions ConfigureOptions
+	argsString := makeArgsString()
+	argsBool := makeArgsBool()
+
+	for k, v := range argsString {
+		v.Value = flag.String(k, "", v.Desc)
+		argsString[k] = v
+	}
+
+	for k, v := range argsBool {
+		v.Enabled = flag.Bool(k, false, v.Desc)
+		argsBool[k] = v
+	}
+
 	flag.Parse()
+
+	configureOptions.Values = argsString
+	configureOptions.Bools = argsBool
 
 	if *versionPrint {
 		printNginxBuildVersion()
@@ -199,7 +217,7 @@ func main() {
 		log.Println("[warn]Using '--add-module' is discouraged. Instead give ini-file with '-m' to 'nginx-build'")
 	}
 
-	configureScript := configureGen(nginxConfigure, modules3rd, dependencies)
+	configureScript := configureGen(nginxConfigure, modules3rd, dependencies, configureOptions)
 	err = ioutil.WriteFile("./nginx-configure", []byte(configureScript), 0655)
 	if err != nil {
 		log.Fatalf("Failed to generate configure script for %s", nginxBuilder.sourcePath())

--- a/util.go
+++ b/util.go
@@ -146,3 +146,22 @@ func clearWorkDir(workDir string) error {
 	}
 	return err
 }
+
+func normalizeAddModulePaths(path, rootDir string) string {
+	var result string
+	if len(path) == 0 {
+		return path
+	}
+
+	module_paths := strings.Split(path, ",")
+
+	for _, module_path := range module_paths {
+		if strings.HasPrefix(module_path, "/") {
+			result += fmt.Sprintf("--add-module=%s \\\n", module_path)
+		} else {
+			result += fmt.Sprintf("--add-module=%s/%s \\\n", rootDir, module_path)
+		}
+	}
+
+	return result
+}

--- a/version.go
+++ b/version.go
@@ -18,7 +18,7 @@ func versionsSubmajorGen(major, submajor, minor int) []string {
 func versionsGen() []string {
 	var versions []string
 
-	versionsMinor0 := []int{45, 6, 61, 14, 38, 39, 69, 55, 7} // 0.x.x
+	versionsMinor0 := []int{45, 6, 61, 14, 38, 39, 69, 55, 7}  // 0.x.x
 	versionsMinor1 := []int{15, 19, 9, 16, 7, 13, 3, 12, 0, 1} // 1.x.x
 
 	// 0.1.0 ~ 0.9.7


### PR DESCRIPTION
Now this implementation has the limitations below.

 * `--with-pcre`(force PCRE library usage) is not allowed
 * `--with-libatomic`(force libatomic_ops library usage) is not allowed

## example

```
$ nginx-build \
-d work \
-pcre \
--with-debug \
--with-threads \
--prefix=/usr/local/nginx \
--with-mail \
--with-stream
nginx-build: 0.3.5
Compiler: gc go1.4.2
2015/06/08 03:06:19 Download nginx-1.9.1.....
2015/06/08 03:06:19 Download pcre-8.37.....
2015/06/08 03:06:22 Extract nginx-1.9.1.tar.gz.....
2015/06/08 03:06:33 Extract pcre-8.37.tar.gz.....
2015/06/08 03:06:33 Generate configure script for nginx-1.9.1.....
2015/06/08 03:06:33 Configure nginx-1.9.1.....
2015/06/08 03:06:37 Build nginx-1.9.1.....
2015/06/08 03:06:53 Complete building nginx!

nginx version: nginx/1.9.1
built by gcc 4.8.2 (Ubuntu 4.8.2-19ubuntu1) 
configure arguments: --with-pcre=../pcre-8.37 --prefix=/usr/local/nginx --with-debug --with-threads --with-stream --with-mail

2015/06/08 03:06:53 Enter the following command for install nginx.

   $ cd work/1.9.1/nginx-1.9.1
   $ sudo make install
$
```
