### PR TITLE
introduced new flags: `--patch` and `--patch-opt` for applying patch to nginx

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@
 
  * [wget](https://www.gnu.org/software/wget/) for downloading nginx and external libraries
  * [git](https://git-scm.com/) and [hg](https://www.mercurial-scm.org/) for downloading 3rd party modules
+ * [patch](http://savannah.gnu.org/projects/patch/) for applying patch to nginx
 
 ## Build Support
 

--- a/option.go
+++ b/option.go
@@ -113,6 +113,14 @@ func makeNginxBuildOptions() Options {
 		Desc:    "tengine version",
 		Default: builder.TENGINE_VERSION,
 	}
+	argsString["patch"] = OptionValue{
+		Desc:    "patch path for applying to nginx",
+		Default: "",
+	}
+	argsString["patch-opt"] = OptionValue{
+		Desc:    "option for patch",
+		Default: "",
+	}
 
 	nginxBuildOptions.Bools = argsBool
 	nginxBuildOptions.Values = argsString

--- a/patch.go
+++ b/patch.go
@@ -1,0 +1,25 @@
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/cubicdaiya/nginx-build/command"
+)
+
+func patch(path, option string) error {
+	args := []string{"sh", "-c"}
+	args = append(args, fmt.Sprintf("patch %s < %s", option, path))
+
+	cmd, err := command.Make(args)
+	if err != nil {
+		return err
+	}
+
+	// As the output of patch is interactive,
+	// the result is always output.
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+
+	return cmd.Run()
+}


### PR DESCRIPTION
## Example

```
nginx-build \
 -d work \
 -patch nginx__http2_spdy.patch \
 -patch-opt "-p1" \
 -v 1.9.7 \
 --with-http_spdy_module \
 --with-http_v2_module
```
