### PR TITLE
option: introduced --idempotent.

### DIFF
--- a/builder/builder.go
+++ b/builder/builder.go
@@ -125,7 +125,7 @@ func (builder *Builder) InstalledVersion() (string, error) {
 	return string(m[1]), nil
 }
 
-func MakeBuilder(component int, version string, static *bool) Builder {
+func MakeBuilder(component int, version string) Builder {
 	var builder Builder
 	builder.Component = component
 	builder.Version = version
@@ -134,13 +134,10 @@ func MakeBuilder(component int, version string, static *bool) Builder {
 		builder.DownloadURLPrefix = NginxDownloadURLPrefix
 	case ComponentPcre:
 		builder.DownloadURLPrefix = PcreDownloadURLPrefix
-		builder.Static = *static
 	case ComponentOpenSSL:
 		builder.DownloadURLPrefix = OpenSSLDownloadURLPrefix
-		builder.Static = *static
 	case ComponentZlib:
 		builder.DownloadURLPrefix = ZlibDownloadURLPrefix
-		builder.Static = *static
 	case ComponentOpenResty:
 		builder.DownloadURLPrefix = OpenRestyDownloadURLPrefix
 	case ComponentTengine:
@@ -148,5 +145,11 @@ func MakeBuilder(component int, version string, static *bool) Builder {
 	default:
 		panic("invalid component")
 	}
+	return builder
+}
+
+func MakeLibraryBuilder(component int, version string, static bool) Builder {
+	builder := MakeBuilder(component, version)
+	builder.Static = static
 	return builder
 }

--- a/builder/builder.go
+++ b/builder/builder.go
@@ -13,6 +13,8 @@ type Builder struct {
 	Version           string
 	DownloadURLPrefix string
 	Component         int
+	// for dependencies such as pcre and zlib and openssl
+	Static bool
 }
 
 var (
@@ -123,7 +125,7 @@ func (builder *Builder) InstalledVersion() (string, error) {
 	return string(m[1]), nil
 }
 
-func MakeBuilder(component int, version string) Builder {
+func MakeBuilder(component int, version string, static *bool) Builder {
 	var builder Builder
 	builder.Component = component
 	builder.Version = version
@@ -132,10 +134,13 @@ func MakeBuilder(component int, version string) Builder {
 		builder.DownloadURLPrefix = NginxDownloadURLPrefix
 	case ComponentPcre:
 		builder.DownloadURLPrefix = PcreDownloadURLPrefix
+		builder.Static = *static
 	case ComponentOpenSSL:
 		builder.DownloadURLPrefix = OpenSSLDownloadURLPrefix
+		builder.Static = *static
 	case ComponentZlib:
 		builder.DownloadURLPrefix = ZlibDownloadURLPrefix
+		builder.Static = *static
 	case ComponentOpenResty:
 		builder.DownloadURLPrefix = OpenRestyDownloadURLPrefix
 	case ComponentTengine:

--- a/builder/builder.go
+++ b/builder/builder.go
@@ -19,7 +19,7 @@ var (
 	nginxVersionRe     *regexp.Regexp
 	pcreVersionRe      *regexp.Regexp
 	zlibVersionRe      *regexp.Regexp
-	openSSLVersionRe   *regexp.Regexp
+	opensslVersionRe   *regexp.Regexp
 	openrestyVersionRe *regexp.Regexp
 	tengineVersionRe   *regexp.Regexp
 )
@@ -28,7 +28,7 @@ func init() {
 	nginxVersionRe = regexp.MustCompile(`nginx version: nginx.(\d+\.\d+\.\d+)`)
 	pcreVersionRe = regexp.MustCompile(`--with-pcre=.+/pcre-(\d+\.\d+)`)
 	zlibVersionRe = regexp.MustCompile(`--with-zlib=.+/zlib-(\d+\.\d+\.\d+)`)
-	openSSLVersionRe = regexp.MustCompile(`--with-openssl=.+/openssl-(\d+\.\d+\.\d+[a-z]+)`)
+	opensslVersionRe = regexp.MustCompile(`--with-openssl=.+/openssl-(\d+\.\d+\.\d+[a-z]+)`)
 	openrestyVersionRe = regexp.MustCompile(`nginx version: openresty/(\d+\.\d+\.\d+\.\d+)`)
 	tengineVersionRe = regexp.MustCompile(`Tengine version: Tengine/(\d+\.\d+\.\d+)`)
 }
@@ -99,47 +99,28 @@ func (builder *Builder) InstalledVersion() (string, error) {
 	}
 
 	openRestyName := openresty.Name(builder.Version)
+	var versionRe *regexp.Regexp
 
 	switch builder.name() {
 	case "nginx":
-		m := nginxVersionRe.FindSubmatch(result)
-		if len(m) < 2 {
-			return "", nil
-		}
-		return string(m[1]), nil
+		versionRe = nginxVersionRe
 	case openRestyName:
-		m := openrestyVersionRe.FindSubmatch(result)
-		if len(m) < 2 {
-			return "", nil
-		}
-		return string(m[1]), nil
+		versionRe = openrestyVersionRe
 	case "zlib":
-		m := zlibVersionRe.FindSubmatch(result)
-		if len(m) < 2 {
-			return "", nil
-		}
-		return string(m[1]), nil
+		versionRe = zlibVersionRe
 	case "pcre":
-		m := pcreVersionRe.FindSubmatch(result)
-		if len(m) < 2 {
-			return "", nil
-		}
-		return string(m[1]), nil
+		versionRe = pcreVersionRe
 	case "openssl":
-		m := openSSLVersionRe.FindSubmatch(result)
-		if len(m) < 2 {
-			return "", nil
-		}
-		return string(m[1]), nil
+		versionRe = opensslVersionRe
 	case "tengine":
-		m := tengineVersionRe.FindSubmatch(result)
-		if len(m) < 2 {
-			return "", nil
-		}
-		return string(m[1]), nil
+		versionRe = tengineVersionRe
 	}
 
-	return "", nil
+	m := versionRe.FindSubmatch(result)
+	if len(m) < 2 {
+		return "", nil
+	}
+	return string(m[1]), nil
 }
 
 func MakeBuilder(component int, version string) Builder {

--- a/builder/builder_test.go
+++ b/builder/builder_test.go
@@ -17,9 +17,9 @@ func (suite *BuilderTestSuite) SetupTest() {
 	suite.builders = make([]Builder, ComponentMax)
 
 	suite.builders[ComponentNginx] = MakeBuilder(ComponentNginx, NginxVersion)
-	suite.builders[ComponentPcre] = MakeBuilder(ComponentPcre, PcreVersion)
-	suite.builders[ComponentOpenSSL] = MakeBuilder(ComponentOpenSSL, OpenSSLVersion)
-	suite.builders[ComponentZlib] = MakeBuilder(ComponentZlib, ZlibVersion)
+	suite.builders[ComponentPcre] = MakeLibraryBuilder(ComponentPcre, PcreVersion, false)
+	suite.builders[ComponentOpenSSL] = MakeLibraryBuilder(ComponentOpenSSL, OpenSSLVersion, true)
+	suite.builders[ComponentZlib] = MakeLibraryBuilder(ComponentZlib, ZlibVersion, false)
 	suite.builders[ComponentOpenResty] = MakeBuilder(ComponentOpenResty, OpenRestyVersion)
 	suite.builders[ComponentTengine] = MakeBuilder(ComponentTengine, TengineVersion)
 }
@@ -73,6 +73,12 @@ func (suite *BuilderTestSuite) TestLogPath() {
 	assert.Equal(suite.T(), suite.builders[ComponentZlib].LogPath(), fmt.Sprintf("zlib-%s.log", ZlibVersion))
 	assert.Equal(suite.T(), suite.builders[ComponentOpenResty].LogPath(), fmt.Sprintf("openresty-%s.log", OpenRestyVersion))
 	assert.Equal(suite.T(), suite.builders[ComponentTengine].LogPath(), fmt.Sprintf("tengine-%s.log", TengineVersion))
+}
+
+func (suite *BuilderTestSuite) TestLibrary() {
+	assert.Equal(suite.T(), suite.builders[ComponentPcre].Static, false)
+	assert.Equal(suite.T(), suite.builders[ComponentOpenSSL].Static, true)
+	assert.Equal(suite.T(), suite.builders[ComponentZlib].Static, false)
 }
 
 func (suite *BuilderTestSuite) TestMakeStaticLibrary() {

--- a/builder/nginx.go
+++ b/builder/nginx.go
@@ -30,3 +30,23 @@ func BuildNginx(jobs int) error {
 
 	return cmd.Run()
 }
+
+func IsSameVersion(builders []builder.Builder) (bool, error) {
+	sameVersion := true
+	for _, b := range builders {
+		vi, err := b.InstalledVersion()
+		if err != nil {
+			return false, err
+		}
+		if vi == b.Version {
+			continue
+		}
+		sameVersion = false
+	}
+
+	if sameVersion {
+		return true
+	}
+
+	return false, nil
+}

--- a/builder/nginx.go
+++ b/builder/nginx.go
@@ -31,7 +31,7 @@ func BuildNginx(jobs int) error {
 	return cmd.Run()
 }
 
-func IsSameVersion(builders []builder.Builder) (bool, error) {
+func IsSameVersion(builders []Builder) (bool, error) {
 	sameVersion := true
 	for _, b := range builders {
 		vi, err := b.InstalledVersion()
@@ -45,7 +45,7 @@ func IsSameVersion(builders []builder.Builder) (bool, error) {
 	}
 
 	if sameVersion {
-		return true
+		return true, nil
 	}
 
 	return false, nil

--- a/builder/nginx.go
+++ b/builder/nginx.go
@@ -38,8 +38,21 @@ func IsSameVersion(builders []Builder) (bool, error) {
 		if err != nil {
 			return false, err
 		}
-		if vi == b.Version {
-			continue
+		switch b.Component {
+		case ComponentPcre:
+			fallthrough
+		case ComponentOpenSSL:
+			fallthrough
+		case ComponentZlib:
+			if vi == "" && !b.Static {
+				continue
+			} else if vi == b.Version && b.Static {
+				continue
+			}
+		default:
+			if vi == b.Version {
+				continue
+			}
 		}
 		sameVersion = false
 	}

--- a/nginx-build.go
+++ b/nginx-build.go
@@ -217,6 +217,7 @@ func main() {
 		}
 		if isSame {
 			log.Println("Installed nginx is same.")
+			return
 		}
 	}
 

--- a/nginx-build.go
+++ b/nginx-build.go
@@ -192,15 +192,15 @@ func main() {
 		log.Fatal("select one between '-openresty' and '-tengine'.")
 	}
 	if *openResty {
-		nginxBuilder = builder.MakeBuilder(builder.ComponentOpenResty, *openRestyVersion, nil)
+		nginxBuilder = builder.MakeBuilder(builder.ComponentOpenResty, *openRestyVersion)
 	} else if *tengine {
-		nginxBuilder = builder.MakeBuilder(builder.ComponentTengine, *tengineVersion, nil)
+		nginxBuilder = builder.MakeBuilder(builder.ComponentTengine, *tengineVersion)
 	} else {
-		nginxBuilder = builder.MakeBuilder(builder.ComponentNginx, *version, nil)
+		nginxBuilder = builder.MakeBuilder(builder.ComponentNginx, *version)
 	}
-	pcreBuilder := builder.MakeBuilder(builder.ComponentPcre, *pcreVersion, pcreStatic)
-	openSSLBuilder := builder.MakeBuilder(builder.ComponentOpenSSL, *openSSLVersion, openSSLStatic)
-	zlibBuilder := builder.MakeBuilder(builder.ComponentZlib, *zlibVersion, zlibStatic)
+	pcreBuilder := builder.MakeLibraryBuilder(builder.ComponentPcre, *pcreVersion, *pcreStatic)
+	openSSLBuilder := builder.MakeLibraryBuilder(builder.ComponentOpenSSL, *openSSLVersion, *openSSLStatic)
+	zlibBuilder := builder.MakeLibraryBuilder(builder.ComponentZlib, *zlibVersion, *zlibStatic)
 
 	if *idempotent {
 		builders := []builder.Builder{

--- a/nginx-build.go
+++ b/nginx-build.go
@@ -209,18 +209,8 @@ func main() {
 			openSSLBuilder,
 			zlibBuilder,
 		}
-		sameVersion := true
-		for _, b := range builders {
-			vi, err := b.InstalledVersion()
-			if err != nil {
-				log.Fatal(err)
-			}
-			if vi == b.Version {
-				continue
-			}
-			sameVersion = false
-		}
-		if sameVersion {
+
+		if builder.IsSameVersion(builders) {
 			log.Println("Installed nginx is same.")
 			return
 		}

--- a/nginx-build.go
+++ b/nginx-build.go
@@ -192,15 +192,15 @@ func main() {
 		log.Fatal("select one between '-openresty' and '-tengine'.")
 	}
 	if *openResty {
-		nginxBuilder = builder.MakeBuilder(builder.ComponentOpenResty, *openRestyVersion)
+		nginxBuilder = builder.MakeBuilder(builder.ComponentOpenResty, *openRestyVersion, nil)
 	} else if *tengine {
-		nginxBuilder = builder.MakeBuilder(builder.ComponentTengine, *tengineVersion)
+		nginxBuilder = builder.MakeBuilder(builder.ComponentTengine, *tengineVersion, nil)
 	} else {
-		nginxBuilder = builder.MakeBuilder(builder.ComponentNginx, *version)
+		nginxBuilder = builder.MakeBuilder(builder.ComponentNginx, *version, nil)
 	}
-	pcreBuilder := builder.MakeBuilder(builder.ComponentPcre, *pcreVersion)
-	openSSLBuilder := builder.MakeBuilder(builder.ComponentOpenSSL, *openSSLVersion)
-	zlibBuilder := builder.MakeBuilder(builder.ComponentZlib, *zlibVersion)
+	pcreBuilder := builder.MakeBuilder(builder.ComponentPcre, *pcreVersion, pcreStatic)
+	openSSLBuilder := builder.MakeBuilder(builder.ComponentOpenSSL, *openSSLVersion, openSSLStatic)
+	zlibBuilder := builder.MakeBuilder(builder.ComponentZlib, *zlibVersion, zlibStatic)
 
 	if *idempotent {
 		builders := []builder.Builder{

--- a/nginx-build.go
+++ b/nginx-build.go
@@ -210,9 +210,13 @@ func main() {
 			zlibBuilder,
 		}
 
-		if builder.IsSameVersion(builders) {
-			log.Println("Installed nginx is same.")
+		isSame, err := builder.IsSameVersion(builders)
+		if err != nil {
+			log.Fatal(err)
 			return
+		}
+		if isSame {
+			log.Println("Installed nginx is same.")
 		}
 	}
 

--- a/option.go
+++ b/option.go
@@ -73,6 +73,9 @@ func makeNginxBuildOptions() Options {
 	argsBool["configureonly"] = OptionBool{
 		Desc: "configure nginx only not building",
 	}
+	argsBool["idempotent"] = OptionBool{
+		Desc: "build nginx if already installed nginx version is different",
+	}
 	argsBool["help-all"] = OptionBool{
 		Desc: "print all flags",
 	}


### PR DESCRIPTION
Previously, nginx-build's behavior is not idempotent. So nginx-build always builds nginx.

If **--idempotent** is given, nginx-build does not build nginx when the version of nginx and dependencies (pcre, openssl, zlib) are same. On the other hand, this feature does not affect 3rd party modules.