### PR TITLE
Release zlib v1.2.9

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ $ nginx-build -d work -zlib
 `-zlibversion` is an option to set a version of zlib.
 
 ```bash
-$ nginx-build -d work -zlib -zlibversion=1.2.8
+$ nginx-build -d work -zlib -zlibversion=1.2.9
 ```
 
 ### Embedding PCRE statically

--- a/builder/const.go
+++ b/builder/const.go
@@ -20,7 +20,7 @@ const (
 
 // zlib
 const (
-	ZlibVersion           = "1.2.8"
+	ZlibVersion           = "1.2.9"
 	ZlibDownloadURLPrefix = "http://zlib.net"
 )
 


### PR DESCRIPTION
http://zlib.net/zlib-1.2.8.tar.gz was not found on its server.