### PR TITLE
zlib: changed download URL prefix.

### DIFF
--- a/builder/const.go
+++ b/builder/const.go
@@ -21,7 +21,7 @@ const (
 // zlib
 const (
 	ZlibVersion           = "1.2.10"
-	ZlibDownloadURLPrefix = "http://zlib.net"
+	ZlibDownloadURLPrefix = "http://zlib.net/fossils"
 )
 
 // openResty


### PR DESCRIPTION
There is not old zlib versions under directly zlib.net. Instead all are archived in fossils.