### PR TITLE
replace wget with the implementation of go

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,6 @@
 
 ## Requirements
 
- * [wget](https://www.gnu.org/software/wget/) for downloading nginx and external libraries
  * [git](https://git-scm.com/) and [hg](https://www.mercurial-scm.org/) for downloading 3rd party modules
  * [patch](http://savannah.gnu.org/projects/patch/) for applying patch to nginx
 

--- a/README.md
+++ b/README.md
@@ -193,6 +193,13 @@ $ nginx-build -d work -libressl
 $ nginx-build -d work -libressl -libresslversion=2.5.4
 ```
 
+Sometimes the following error occurs when downloading the source code. Downloading the source code has been successful, so you do not have to worry about it.
+
+```
+Unsolicited response received on idle HTTP channel starting with "HTTP/1.0 408 Request Timeout\r\nDate: Sat, 22 Jul 2017 06:55:35 GMT\r\nServer: OpenBSD httpd\r\nConnection: close\r\nContent-Type: text/html\r\nContent-Length: 439\r\n\r\n<!DOCTYPE html>\n<html>\n<head>\n<meta http-equiv=\"Content-Type\" content=\"text/html; charset=utf-8\"/>\n<title>408 Request Timeout</title>\n<style type=\"text/css\"><!--\nbody { background-color: white; color: black; font-family: 'Comic Sans MS', 'Chalkboard SE', 'Comic Neue', sans-serif; }\nhr { border: 0; border-bottom: 1px dashed; }\n\n--></style>\n</head>\n<body>\n<h1>408 Request Timeout</h1>\n<hr>\n<address>OpenBSD httpd</address>\n</body>\n</html>\n"; err=<nil>
+```
+
+
 ### Embedding 3rd-party modules
 
 `nginx-build` provides a mechanism for embedding 3rd-party modules.

--- a/README.md
+++ b/README.md
@@ -192,11 +192,8 @@ $ nginx-build -d work -libressl
 $ nginx-build -d work -libressl -libresslversion=2.5.4
 ```
 
-Sometimes the following error occurs when downloading the source code. Downloading the source code has been successful, so you do not have to worry about it.
-
-```
-Unsolicited response received on idle HTTP channel starting with "HTTP/1.0 408 Request Timeout\r\nDate: Sat, 22 Jul 2017 06:55:35 GMT\r\nServer: OpenBSD httpd\r\nConnection: close\r\nContent-Type: text/html\r\nContent-Length: 439\r\n\r\n<!DOCTYPE html>\n<html>\n<head>\n<meta http-equiv=\"Content-Type\" content=\"text/html; charset=utf-8\"/>\n<title>408 Request Timeout</title>\n<style type=\"text/css\"><!--\nbody { background-color: white; color: black; font-family: 'Comic Sans MS', 'Chalkboard SE', 'Comic Neue', sans-serif; }\nhr { border: 0; border-bottom: 1px dashed; }\n\n--></style>\n</head>\n<body>\n<h1>408 Request Timeout</h1>\n<hr>\n<address>OpenBSD httpd</address>\n</body>\n</html>\n"; err=<nil>
-```
+Sometimes an error occurs when downloading the source code. Please refer to the following [PR](https://github.com/cubicdaiya/nginx-build/pull/25) for more information.
+Downloading the source code has been successful, so you do not have to worry about it.
 
 
 ### Embedding 3rd-party modules

--- a/download.go
+++ b/download.go
@@ -13,7 +13,7 @@ import (
 	"github.com/cubicdaiya/nginx-build/util"
 )
 
-const DefaultTimeout = time.Duration(900) * time.Second
+const DefaultDownloadTimeout = time.Duration(900) * time.Second
 
 func extractArchive(path string) error {
 	return command.Run([]string{"tar", "zxvf", path})
@@ -21,7 +21,7 @@ func extractArchive(path string) error {
 
 func download(b *builder.Builder) error {
 	c := &http.Client{
-		Timeout: DefaultTimeout,
+		Timeout: DefaultDownloadTimeout,
 	}
 
 	res, err := c.Get(b.DownloadURL())

--- a/download.go
+++ b/download.go
@@ -6,6 +6,7 @@ import (
 	"log"
 	"net/http"
 	"os"
+	"time"
 
 	"github.com/cubicdaiya/nginx-build/builder"
 	"github.com/cubicdaiya/nginx-build/command"
@@ -17,7 +18,11 @@ func extractArchive(path string) error {
 }
 
 func downloadForBuilder(b *builder.Builder) error {
-	res, err := http.Get(b.DownloadURL())
+	c := &http.Client{
+		Timeout: time.Duration(900) * time.Second, // the default timeout of wget
+	}
+
+	res, err := c.Get(b.DownloadURL())
 	if err != nil {
 		return err
 	}

--- a/download.go
+++ b/download.go
@@ -13,13 +13,15 @@ import (
 	"github.com/cubicdaiya/nginx-build/util"
 )
 
+const DefaultTimeout = time.Duration(900) * time.Second
+
 func extractArchive(path string) error {
 	return command.Run([]string{"tar", "zxvf", path})
 }
 
-func downloadForBuilder(b *builder.Builder) error {
+func download(b *builder.Builder) error {
 	c := &http.Client{
-		Timeout: time.Duration(900) * time.Second, // the default timeout of wget
+		Timeout: DefaultTimeout,
 	}
 
 	res, err := c.Get(b.DownloadURL())
@@ -48,7 +50,7 @@ func downloadAndExtract(b *builder.Builder) error {
 
 			log.Printf("Download %s.....", b.SourcePath())
 
-			err := downloadForBuilder(b)
+			err := download(b)
 			if err != nil {
 				return fmt.Errorf("Failed to download %s. %s", b.SourcePath(), err.Error())
 			}


### PR DESCRIPTION
refs #1 

This commit works correctly. But an error is displayed when downloading LibreSSL.

```
Unsolicited response received on idle HTTP channel starting with "HTTP/1.0 408 Request Timeout\r\nDate: Sun, 16 Jul 2017 15:04:06 GMT\r\nServer: OpenBSD httpd\r\nConnection: close\r\nCo
ntent-Type: text/html\r\nContent-Length: 439\r\n\r\n<!DOCTYPE html>\n<html>\n<head>\n<meta http-equiv=\"Content-Type\" content=\"text/html; charset=utf-8\"/>\n<title>408 Request Timeout</title>\n<style typ
e=\"text/css\"><!--\nbody { background-color: white; color: black; font-family: 'Comic Sans MS', 'Chalkboard SE', 'Comic Neue', sans-serif; }\nhr { border: 0; border-bottom: 1px dashed; }\n\n--></style>\n<
/head>\n<body>\n<h1>408 Request Timeout</h1>\n<hr>\n<address>OpenBSD httpd</address>\n</body>\n</html>\n"; err=<nil>
```

cf: https://github.com/golang/go/issues/12855
cf: https://github.com/golang/go/issues/19895
cf: https://github.com/golang/go/issues/2057

Even if an error is displayed, execution will not stop so there is no problem.

The location where the file is saved is the same as when `wget` is used because we use `os.Chdir` in the program. If you want to remove `os.Chdir`, we needs to remove `tar`.

## Why do I want to replace wget with the implementation of go

`wget` is not preinstalled by default on Mac.

I often use Docker with minimal configuration Linux distribution. In such a distribution, `wget` may not be installed.