### PR TITLE
update LibreSSL version to 2.6.3 by default

### DIFF
--- a/builder/const.go
+++ b/builder/const.go
@@ -20,7 +20,7 @@ const (
 
 // libressl
 const (
-	LibreSSLVersion           = "2.5.5"
+	LibreSSLVersion           = "2.6.3"
 	LibreSSLDownloadURLPrefix = "https://ftp.openbsd.org/pub/OpenBSD/LibreSSL"
 )
 


### PR DESCRIPTION
LibreSSL 2.6.3 is the new stable version.
https://ftp.openbsd.org/pub/OpenBSD/LibreSSL/libressl-2.6.3-relnotes.txt