### PR TITLE
update LibreSSL version to 2.6.4 by default

### DIFF
--- a/builder/const.go
+++ b/builder/const.go
@@ -20,7 +20,7 @@ const (
 
 // libressl
 const (
-	LibreSSLVersion           = "2.6.3"
+	LibreSSLVersion           = "2.6.4"
 	LibreSSLDownloadURLPrefix = "https://ftp.openbsd.org/pub/OpenBSD/LibreSSL"
 )
 


### PR DESCRIPTION
LibreSSL 2.6.4 is the new stable version.
https://ftp.openbsd.org/pub/OpenBSD/LibreSSL/libressl-2.6.4-relnotes.txt