### PR TITLE
add work directory to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ vendor
 doc/_build/doctrees/
 *.tar
 *.tar.gz
+work


### PR DESCRIPTION
Executing the command as written in the README will create a work directory.
I want to add it because it is inconvenient.