### PR TITLE
update LibreSSL version to 2.7.2 by default

### DIFF
--- a/builder/const.go
+++ b/builder/const.go
@@ -20,7 +20,7 @@ const (
 
 // libressl
 const (
-	LibreSSLVersion           = "2.6.4"
+	LibreSSLVersion           = "2.7.2"
 	LibreSSLDownloadURLPrefix = "https://ftp.openbsd.org/pub/OpenBSD/LibreSSL"
 )
 


### PR DESCRIPTION
LibreSSL 2.7.2 is the new stable version.
https://ftp.openbsd.org/pub/OpenBSD/LibreSSL/libressl-2.7.2-relnotes.txt