### PR TITLE
support patches directory

### DIFF
--- a/util/file.go
+++ b/util/file.go
@@ -15,6 +15,30 @@ func FileExists(path string) bool {
 	return true
 }
 
+func IsDirectory(path string) (bool, error) {
+	stat, err := os.Stat(path)
+	if err != nil {
+		return false, err
+	}
+	return stat.IsDir(), nil
+}
+
+func ListDirectory(path string) ([]string, error) {
+	var fileNames []string
+
+	err := filepath.Walk(path, func (path string, info os.FileInfo, err error) error {
+		if ! info.IsDir() {
+			fileNames = append(fileNames, path)
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return fileNames, nil
+}
+
 func SaveCurrentDir() string {
 	prevDir, _ := filepath.Abs(".")
 	return prevDir

--- a/util/patch.go
+++ b/util/patch.go
@@ -65,11 +65,33 @@ func Patch(path, option, root string, reverse bool) {
 		pathes = append(pathes, path)
 	}
 
+	// replace directories with all files they contain (recursively)
+	var expanded_paths []string
 	for _, path := range pathes {
-
 		if !strings.HasPrefix(path, "/") {
 			path = fmt.Sprintf("%s/%s", root, path)
 		}
+
+		isDir, err := IsDirectory(path)
+		if err != nil {
+			log.Fatal(err)
+		}
+		if isDir {
+			paths, err := ListDirectory(path)
+			if err != nil {
+				log.Fatal(err)
+			}
+			if paths != nil {
+				expanded_paths = append(expanded_paths, paths...)
+			}
+		} else {
+			expanded_paths = append(expanded_paths, path)
+		}
+	}
+
+	pathes = expanded_paths
+
+	for _, path := range pathes {
 		if FileExists(path) {
 			if reverse {
 				log.Printf("Reverting patch: %s", path)


### PR DESCRIPTION
Opening for discussion/consideration:

Make `--patch` flag support directories in addition to regular files; if a
path is detected as a directory, all of its files are resolved, assumed
to be patches, and applied.

I've been using it on my local; if it could potentially benefit others, I'd be
happy to improve the implementation. As it is now, it's not very elegant,
but keeps changes to a minimum.

Possible improvements:
- Make sure expanded files in directories are actually patch files before
applying them - perhaps not needed, as `patch(1)` itself will validate
- We could try to avoid creating a new array, and expand in the same 
`pathes` array
- ~As of now, all files in directories are assumed to be patches, so no
support for nested directories~ (this is now implemented)