### PR TITLE
openresty: support release candidates

### DIFF
--- a/openresty/openresty.go
+++ b/openresty/openresty.go
@@ -4,9 +4,20 @@ import (
 	"math"
 	"strconv"
 	"strings"
+	"regexp"
 )
 
+var (
+	versionPattern *regexp.Regexp
+)
+
+func init() {
+	versionPattern = regexp.MustCompile(`([0-9]+)(\.[0-9]+)?(\.[0-9]+)?(\.[0-9]+)?`)
+}
+
 func Name(version string) string {
+	version = versionPattern.FindString(version)
+
 	numbers := strings.Split(version, ".")
 	size := len(numbers)
 	sum := 0

--- a/openresty/openresty_test.go
+++ b/openresty/openresty_test.go
@@ -12,4 +12,5 @@ func TestOpenrestyName(t *testing.T) {
 	assert.Equal("ngx_openresty", Name("1.9.7.2"))
 	assert.Equal("openresty", Name("1.9.7.3"))
 	assert.Equal("openresty", Name("1.9.7.4"))
+	assert.Equal("openresty", Name("1.15.8.1rc1"))
 }


### PR DESCRIPTION
Currently, as RC versions include an `rcX` suffix, the Name function in
the openresty module won't return a valid result - as one of the version
components will be non-numeric, the `Atoi` call will return an error and
the `ngx_openresty` (used for older versions) will be returned. 