### PR TITLE
bumped default LibreSSL version to 2.9.2

### DIFF
--- a/builder/const.go
+++ b/builder/const.go
@@ -20,7 +20,7 @@ const (
 
 // libressl
 const (
-	LibreSSLVersion           = "2.8.3"
+	LibreSSLVersion           = "2.9.2"
 	LibreSSLDownloadURLPrefix = "https://ftp.openbsd.org/pub/OpenBSD/LibreSSL"
 )
 


### PR DESCRIPTION
this version fails to build on mac.
But I can build it on Linux. It is not a problem with nginx-build.