### PR TITLE
add CircleCI for releasing automatically

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,62 @@
+# Golang CircleCI 2.0 configuration file
+#
+# Check https://circleci.com/docs/2.0/language-go/ for more details
+version: 2
+jobs:
+  build:
+    docker:
+      # specify the version
+      - image: circleci/golang:1.12
+
+      # Specify service dependencies here if necessary
+      # CircleCI maintains a library of pre-built images
+      # documented at https://circleci.com/docs/2.0/circleci-images/
+      # - image: circleci/postgres:9.4
+
+    #### TEMPLATE_NOTE: go expects specific checkout path representing url
+    #### expecting it in the form of
+    ####   /go/src/github.com/circleci/go-tool
+    ####   /go/src/bitbucket.org/circleci/go-tool
+    working_directory: /go/src/github.com/cubicdaiya/nginx-build
+    steps:
+      - checkout
+
+      # specify any bash command here prefixed with `run: `
+      - run: make
+      - run: make check
+      - run: make release
+
+      - persist_to_workspace:
+          root: release/
+          paths:
+            - nginx-build-linux-amd64.tar.gz
+            - nginx-build-darwin-amd64.tar.gz
+
+  publish-github-release:
+    docker:
+      - image: cibuilds/github:0.10
+    steps:
+      - attach_workspace:
+          at: ./artifacts
+      - run:
+          name: "Publish Release on GitHub"
+          command: |
+            ghr -t ${GITHUB_TOKEN} -u ${CIRCLE_PROJECT_USERNAME} -r ${CIRCLE_PROJECT_REPONAME} -c ${CIRCLE_SHA1} -delete ${CIRCLE_TAG} ./artifacts/
+
+# cf: https://circleci.com/blog/publishing-to-github-releases-via-circleci/
+workflows:
+  version: 2
+  main:
+    jobs:
+      - build:
+          filters:
+            tags:
+              only: /^v[0-9]+\.[0-9]+\.[0-9]+$/
+      - publish-github-release:
+          requires:
+            - build
+          filters:
+            branches:
+              ignore: /.*/
+            tags:
+              only: /^v[0-9]+\.[0-9]+\.[0-9]+$/

--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,15 @@ dist: build-cross
 	cd bin/linux/amd64/ && tar cvf nginx-build-linux-amd64-${VERSION}.tar nginx-build && zopfli nginx-build-linux-amd64-${VERSION}.tar
 	cd bin/darwin/amd64/ && tar cvf nginx-build-darwin-amd64-${VERSION}.tar nginx-build && zopfli nginx-build-darwin-amd64-${VERSION}.tar
 
+.PHONY: release
+release:
+	mkdir release
+	GO111MODULE=on GOOS=linux go build -ldflags '-s -w -X main.NginxBuildVersion=${VERSION}' -o nginx-build
+	tar cvzf release/nginx-build-linux-amd64.tar.gz nginx-build
+	GO111MODULE=on GOOS=darwin go build -ldflags '-s -w -X main.NginxBuildVersion=${VERSION}' -o nginx-build
+	tar cvzf release/nginx-build-darwin-amd64.tar.gz nginx-build
+	rm nginx-build
+
 # ImageMagick and GD are required for ngx_small_light
 build-example: nginx-build
 	./nginx-build -c config/configure.example -m config/modules.cfg.example -d work -clear


### PR DESCRIPTION
If you provided the git tag, nginx-build is released by CircleCI automatically.
If you want to use it, you have to add the project on CircleCI and add GITHUB_TOKEN as an environment variable.
Now, we use travis-ci. If this PR is merged, it is unnecessary.

If you are not interested in automating the release, please close it.