### PR TITLE
use OpenSSL 1.1.1 as the default version

### DIFF
--- a/builder/const.go
+++ b/builder/const.go
@@ -14,7 +14,7 @@ const (
 
 // openssl
 const (
-	OpenSSLVersion           = "1.0.2t"
+	OpenSSLVersion           = "1.1.1d"
 	OpenSSLDownloadURLPrefix = "https://www.openssl.org/source"
 )
 


### PR DESCRIPTION
OpenSSL 1.0.2 will be End Of Life at the end of this year.
So, we should use OpenSSL 1.1.1 as the default version.
cf: https://www.openssl.org/blog/blog/2019/11/07/3.0-update/