### PR TITLE
bumped default OpenResty version to 1.15.8.3

### DIFF
--- a/builder/const.go
+++ b/builder/const.go
@@ -32,7 +32,7 @@ const (
 
 // openResty
 const (
-	OpenRestyVersion           = "1.15.8.2"
+	OpenRestyVersion           = "1.15.8.3"
 	OpenRestyDownloadURLPrefix = "https://openresty.org/download"
 )
 


### PR DESCRIPTION
refs: https://openresty.org/en/changelog-1015008.html