### PR TITLE
bumped default LibreSSL version to 3.0.2

### DIFF
--- a/builder/const.go
+++ b/builder/const.go
@@ -20,7 +20,7 @@ const (
 
 // libressl
 const (
-	LibreSSLVersion           = "2.9.2"
+	LibreSSLVersion           = "3.0.2"
 	LibreSSLDownloadURLPrefix = "https://ftp.openbsd.org/pub/OpenBSD/LibreSSL"
 )
 


### PR DESCRIPTION
refs:
https://ftp.openbsd.org/pub/OpenBSD/LibreSSL/libressl-3.0.2-relnotes.txt