### PR TITLE
build: darwin-arm64 binary.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,10 +8,12 @@ nginx-build: *.go builder/*.go command/*.go configure/*.go module3rd/*.go openre
 build-cross:
 	GOOS=linux GOARCH=amd64 go build -ldflags '-s -w -X main.NginxBuildVersion=${VERSION}' -o bin/linux/amd64/nginx-build
 	GOOS=darwin GOARCH=amd64 go build -ldflags '-s -w -X main.NginxBuildVersion=${VERSION}' -o bin/darwin/amd64/nginx-build
+	GOOS=darwin GOARCH=arm64 go build -ldflags '-s -w -X main.NginxBuildVersion=${VERSION}' -o bin/darwin/arm64/nginx-build
 
 dist: build-cross
 	cd bin/linux/amd64/ && tar cvf nginx-build-linux-amd64-${VERSION}.tar nginx-build && zopfli nginx-build-linux-amd64-${VERSION}.tar
 	cd bin/darwin/amd64/ && tar cvf nginx-build-darwin-amd64-${VERSION}.tar nginx-build && zopfli nginx-build-darwin-amd64-${VERSION}.tar
+	cd bin/darwin/arm64/ && tar cvf nginx-build-darwin-arm64-${VERSION}.tar nginx-build && zopfli nginx-build-darwin-arm64-${VERSION}.tar
 
 # ImageMagick and GD are required for ngx_small_light
 build-example: nginx-build
@@ -35,3 +37,4 @@ clean:
 	rm -rf nginx-build
 	rm -rf bin/linux/amd64/nginx-build*
 	rm -rf bin/darwin/amd64/nginx-build*
+	rm -rf bin/darwin/arm64/nginx-build*


### PR DESCRIPTION
Go1.16 started to support a build with GOOS=darwin,GOARCH=arm64.

https://golang.org/doc/go1.16