### PR TITLE
update LibreSSL version to 3.2.4

### DIFF
--- a/builder/const.go
+++ b/builder/const.go
@@ -20,7 +20,7 @@ const (
 
 // libressl
 const (
-	LibreSSLVersion           = "3.0.2"
+	LibreSSLVersion           = "3.2.4"
 	LibreSSLDownloadURLPrefix = "https://ftp.openbsd.org/pub/OpenBSD/LibreSSL"
 )
 


### PR DESCRIPTION
The latest stable release is 3.2.4
https://ftp.openbsd.org/pub/OpenBSD/LibreSSL/libressl-3.2.4-relnotes.txt