### PR TITLE
use goreleaser for auto binary release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,22 @@
+name: release
+on:
+  push:
+    tags:
+    - "v[0-9]+.[0-9]+.[0-9]+"
+jobs:
+  goreleaser:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Setup Go
+        uses: actions/setup-go@v3
+        with:
+          go-version: 1.18.x
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v2
+        with:
+          version: latest
+          args: release --rm-dist
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,9 +1,6 @@
 project_name: nginx-build
 env:
   - GO111MODULE=on
-before:
-  hooks:
-    - go mod tidy
 builds:
   - main: ./nginx-build.go
     binary: nginx-build

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,21 @@
+project_name: nginx-build
+env:
+  - GO111MODULE=on
+before:
+  hooks:
+    - go mod tidy
+builds:
+  - main: ./nginx-build.go
+    binary: nginx-build
+    ldflags:
+      - -s -w
+      - -X main.NginxBuildVersion={{.Version}}
+    env:
+      - CGO_ENABLED=0
+    goarch:
+      - amd64
+      - arm64
+archives:
+  - name_template: '{{ .ProjectName }}-{{ .Os }}-{{ .Arch }}-{{ .Version }}'
+release:
+  prerelease: auto


### PR DESCRIPTION
refs: #78

I recommend using `debug.ReadBuildInfo` to manage the version automatically.
If you only use binary releases, you can use this change. But It's hard check for me.