### PR TITLE
style: migrate functions in io/ioutils package to os package.

### DIFF
--- a/nginx-build.go
+++ b/nginx-build.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"flag"
-	"io/ioutil"
 	"log"
 	"os"
 	"os/signal"
@@ -387,7 +386,7 @@ func main() {
 
 	configureScript := configure.Generate(nginxConfigure, modules3rd, dependencies, configureOptions, rootDir, *openResty, *jobs)
 
-	err = ioutil.WriteFile("./nginx-configure", []byte(configureScript), 0655)
+	err = os.WriteFile("./nginx-configure", []byte(configureScript), 0655)
 	if err != nil {
 		log.Fatalf("Failed to generate configure script for %s", nginxBuilder.SourcePath())
 	}

--- a/util/file.go
+++ b/util/file.go
@@ -2,7 +2,6 @@ package util
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 )
@@ -47,7 +46,7 @@ func SaveCurrentDir() string {
 func FileGetContents(path string) (string, error) {
 	conf := ""
 	if len(path) > 0 {
-		confb, err := ioutil.ReadFile(path)
+		confb, err := os.ReadFile(path)
 		if err != nil {
 			return "", fmt.Errorf("confPath(%s) does not exist.", path)
 		}


### PR DESCRIPTION
These are deprecated from Go1.16.