### PR TITLE
Add more context when failing to unmarshal JSON

### DIFF
--- a/module3rd/load.go
+++ b/module3rd/load.go
@@ -19,7 +19,7 @@ func Load(path string) ([]Module3rd, error) {
 			return modules, err
 		}
 		if err := json.Unmarshal(data, &modules); err != nil {
-			return modules, err
+			return modules, fmt.Errorf("modulesConfPath(%s) is invalid JSON.", path)
 		}
 		for i, _ := range modules {
 			if modules[i].Form == "" {


### PR DESCRIPTION
When failing to unmarshal JSON that modulesConfPath, nginx-build shows error like:
```
invalid character 'g' in literal null (expecting 'u')
```
This message doesn't tell enough information to fix. This p-r makes showing more contextual informations.