### PR TITLE
simplified the output of "nginx-build -versions".

### DIFF
--- a/version.go
+++ b/version.go
@@ -7,68 +7,10 @@ import (
 	"github.com/cubicdaiya/nginx-build/builder"
 )
 
-func versionsSubmajorGen(major, submajor, minor int) []string {
-	var versions []string
-
-	for i := 0; i <= minor; i++ {
-		v := fmt.Sprintf("%d.%d.%d", major, submajor, i)
-		versions = append(versions, v)
+func versionsGenNginx() []string {
+	return []string{
+		fmt.Sprintf("nginx-%s", builder.NginxVersion),
 	}
-	return versions
-}
-
-func versionsGen() []string {
-	var versions []string
-	// 0.x.x
-	versionsMinor0 := []int{
-		45, // 0.1.x
-		6,  // 0.2.x
-		61, // 0.3.x
-		14, // 0.4.x
-		38, // 0.5.x
-		39, // 0.6.x
-		69, // 0.7.x
-		55, // 0.8.x
-		7,  // 0.9.x
-	}
-	// 1.x.x
-	versionsMinor1 := []int{
-		15, // 1.0.x
-		19, // 1.1.x
-		9,  // 1.2.x
-		16, // 1.3.x
-		7,  // 1.4.x
-		13, // 1.5.x
-		3,  // 1.6.x
-		12, // 1.7.x
-		1,  // 1.8.x
-		15, // 1.9.x
-		3,  // 1.10.x
-		13, // 1.11.x
-		2,  // 1.12.x
-		12, // 1.13.x
-		2,  // 1.14.x
-		12, // 1.15.x
-		1,  // 1.16.x
-		9,  // 1.17.x
-		0,  // 1.18.x
-		10, // 1.19.x
-		2,  // 1.20.x
-		6,  // 1.21.x
-		0,  // 1.22.x
-	}
-
-	// 0.1.0 ~ 0.9.7
-	for i := 0; i < len(versionsMinor0); i++ {
-		versions = append(versions, versionsSubmajorGen(0, i+1, versionsMinor0[i])...)
-	}
-
-	// 1.0.0 ~
-	for i := 0; i < len(versionsMinor1); i++ {
-		versions = append(versions, versionsSubmajorGen(1, i, versionsMinor1[i])...)
-	}
-
-	return versions
 }
 
 func versionsGenOpenResty() []string {
@@ -84,7 +26,8 @@ func versionsGenTengine() []string {
 }
 
 func printNginxVersions() {
-	versions := versionsGen()
+	var versions []string
+	versions = append(versions, versionsGenNginx()...)
 	versions = append(versions, versionsGenOpenResty()...)
 	versions = append(versions, versionsGenTengine()...)
 	for _, v := range versions {


### PR DESCRIPTION
Previously, `nginx-build -versions` intended to output all nginx versions contain old versions. Since this behavior is noisy and not very helpful, this PR changes this behavior to output only the latest stable version.