### PR TITLE
feature: introduced -dltimeout option to control timeout for download.

### DIFF
--- a/builder/builder.go
+++ b/builder/builder.go
@@ -5,15 +5,19 @@ import (
 	"os"
 	"regexp"
 	"strings"
+	"time"
 
 	"github.com/cubicdaiya/nginx-build/command"
 	"github.com/cubicdaiya/nginx-build/openresty"
 )
 
+const DefaultDownloadTimeout = time.Duration(900) * time.Second
+
 type Builder struct {
 	Version           string
 	DownloadURLPrefix string
 	Component         int
+	DownloadTimeout   time.Duration
 	// for dependencies such as pcre and zlib and openssl
 	Static bool
 }
@@ -148,10 +152,11 @@ func (builder *Builder) InstalledVersion() (string, error) {
 	return string(m[1]), nil
 }
 
-func MakeBuilder(component int, version string) Builder {
+func MakeBuilder(component int, version string, timeout time.Duration) Builder {
 	var builder Builder
 	builder.Component = component
 	builder.Version = version
+	builder.DownloadTimeout = timeout
 	switch component {
 	case ComponentNginx:
 		builder.DownloadURLPrefix = NginxDownloadURLPrefix
@@ -173,8 +178,8 @@ func MakeBuilder(component int, version string) Builder {
 	return builder
 }
 
-func MakeLibraryBuilder(component int, version string, static bool) Builder {
-	builder := MakeBuilder(component, version)
+func MakeLibraryBuilder(component int, version string, timeout time.Duration, static bool) Builder {
+	builder := MakeBuilder(component, version, timeout)
 	builder.Static = static
 	return builder
 }

--- a/builder/builder_test.go
+++ b/builder/builder_test.go
@@ -3,17 +3,18 @@ package builder
 import (
 	"fmt"
 	"testing"
+	"time"
 )
 
 func setupBuilders(t *testing.T) []Builder {
 	builders := make([]Builder, ComponentMax)
-	builders[ComponentNginx] = MakeBuilder(ComponentNginx, NginxVersion)
-	builders[ComponentPcre] = MakeLibraryBuilder(ComponentPcre, PcreVersion, false)
-	builders[ComponentOpenSSL] = MakeLibraryBuilder(ComponentOpenSSL, OpenSSLVersion, true)
-	builders[ComponentLibreSSL] = MakeLibraryBuilder(ComponentLibreSSL, LibreSSLVersion, true)
-	builders[ComponentZlib] = MakeLibraryBuilder(ComponentZlib, ZlibVersion, false)
-	builders[ComponentOpenResty] = MakeBuilder(ComponentOpenResty, OpenRestyVersion)
-	builders[ComponentTengine] = MakeBuilder(ComponentTengine, TengineVersion)
+	builders[ComponentNginx] = MakeBuilder(ComponentNginx, NginxVersion, DefaultDownloadTimeout)
+	builders[ComponentPcre] = MakeLibraryBuilder(ComponentPcre, PcreVersion, DefaultDownloadTimeout, false)
+	builders[ComponentOpenSSL] = MakeLibraryBuilder(ComponentOpenSSL, OpenSSLVersion, DefaultDownloadTimeout, true)
+	builders[ComponentLibreSSL] = MakeLibraryBuilder(ComponentLibreSSL, LibreSSLVersion, DefaultDownloadTimeout, true)
+	builders[ComponentZlib] = MakeLibraryBuilder(ComponentZlib, ZlibVersion, DefaultDownloadTimeout, false)
+	builders[ComponentOpenResty] = MakeBuilder(ComponentOpenResty, OpenRestyVersion, DefaultDownloadTimeout)
+	builders[ComponentTengine] = MakeBuilder(ComponentTengine, TengineVersion, DefaultDownloadTimeout)
 	return builders
 }
 
@@ -308,26 +309,31 @@ func TestMakeStaticLibrary(t *testing.T) {
 		builder       Builder
 		staticLibrary StaticLibrary
 		version       string
+		timeout       time.Duration
 	}{
 		{
 			builder:       builders[ComponentPcre],
 			staticLibrary: MakeStaticLibrary(&builders[ComponentPcre]),
 			version:       PcreVersion,
+			timeout:       DefaultDownloadTimeout,
 		},
 		{
 			builder:       builders[ComponentOpenSSL],
 			staticLibrary: MakeStaticLibrary(&builders[ComponentOpenSSL]),
 			version:       OpenSSLVersion,
+			timeout:       DefaultDownloadTimeout,
 		},
 		{
 			builder:       builders[ComponentLibreSSL],
 			staticLibrary: MakeStaticLibrary(&builders[ComponentLibreSSL]),
 			version:       LibreSSLVersion,
+			timeout:       DefaultDownloadTimeout,
 		},
 		{
 			builder:       builders[ComponentZlib],
 			staticLibrary: MakeStaticLibrary(&builders[ComponentZlib]),
 			version:       ZlibVersion,
+			timeout:       DefaultDownloadTimeout,
 		},
 	}
 
@@ -340,6 +346,9 @@ func TestMakeStaticLibrary(t *testing.T) {
 		}
 		if test.builder.Version != test.version {
 			t.Fatalf("not equal version between builder's and default's")
+		}
+		if test.builder.DownloadTimeout != test.timeout {
+			t.Fatalf("not equal download timeout between builder's and default's")
 		}
 	}
 }

--- a/configure/configure_test.go
+++ b/configure/configure_test.go
@@ -11,9 +11,9 @@ import (
 
 func setupBuilders(t *testing.T) []builder.Builder {
 	builders := make([]builder.Builder, builder.ComponentMax)
-	builders[builder.ComponentPcre] = builder.MakeBuilder(builder.ComponentPcre, builder.PcreVersion)
-	builders[builder.ComponentOpenSSL] = builder.MakeBuilder(builder.ComponentOpenSSL, builder.OpenSSLVersion)
-	builders[builder.ComponentZlib] = builder.MakeBuilder(builder.ComponentZlib, builder.ZlibVersion)
+	builders[builder.ComponentPcre] = builder.MakeBuilder(builder.ComponentPcre, builder.PcreVersion, builder.DefaultDownloadTimeout)
+	builders[builder.ComponentOpenSSL] = builder.MakeBuilder(builder.ComponentOpenSSL, builder.OpenSSLVersion, builder.DefaultDownloadTimeout)
+	builders[builder.ComponentZlib] = builder.MakeBuilder(builder.ComponentZlib, builder.ZlibVersion, builder.DefaultDownloadTimeout)
 	return builders
 }
 

--- a/download.go
+++ b/download.go
@@ -6,14 +6,11 @@ import (
 	"log"
 	"net/http"
 	"os"
-	"time"
 
 	"github.com/cubicdaiya/nginx-build/builder"
 	"github.com/cubicdaiya/nginx-build/command"
 	"github.com/cubicdaiya/nginx-build/util"
 )
-
-const DefaultDownloadTimeout = time.Duration(900) * time.Second
 
 func extractArchive(path string) error {
 	return command.Run([]string{"tar", "zxvf", path})
@@ -21,7 +18,7 @@ func extractArchive(path string) error {
 
 func download(b *builder.Builder) error {
 	c := &http.Client{
-		Timeout: DefaultDownloadTimeout,
+		Timeout: b.DownloadTimeout,
 	}
 	res, err := c.Get(b.DownloadURL())
 	if err != nil {

--- a/nginx-build.go
+++ b/nginx-build.go
@@ -75,6 +75,11 @@ func main() {
 		nginxBuildOptions.Numbers[k] = v
 	}
 
+	for k, v := range nginxBuildOptions.Times {
+		v.Value = flag.Duration(k, v.Default, v.Desc)
+		nginxBuildOptions.Times[k] = v
+	}
+
 	overrideUnableParseFlags()
 
 	var (
@@ -135,6 +140,8 @@ func main() {
 	tengineVersion := nginxBuildOptions.Values["tengineversion"].Value
 	patchOption := nginxBuildOptions.Values["patch-opt"].Value
 
+	dltimeout := nginxBuildOptions.Times["dltimeout"].Value
+
 	// Allow multiple flags for `--patch`
 	{
 		tmp := nginxBuildOptions.Values["patch"]
@@ -191,16 +198,16 @@ func main() {
 		log.Fatal("select one between '-openssl' and '-libressl'.")
 	}
 	if *openResty {
-		nginxBuilder = builder.MakeBuilder(builder.ComponentOpenResty, *openRestyVersion)
+		nginxBuilder = builder.MakeBuilder(builder.ComponentOpenResty, *openRestyVersion, *dltimeout)
 	} else if *tengine {
-		nginxBuilder = builder.MakeBuilder(builder.ComponentTengine, *tengineVersion)
+		nginxBuilder = builder.MakeBuilder(builder.ComponentTengine, *tengineVersion, *dltimeout)
 	} else {
-		nginxBuilder = builder.MakeBuilder(builder.ComponentNginx, *version)
+		nginxBuilder = builder.MakeBuilder(builder.ComponentNginx, *version, *dltimeout)
 	}
-	pcreBuilder := builder.MakeLibraryBuilder(builder.ComponentPcre, *pcreVersion, *pcreStatic)
-	openSSLBuilder := builder.MakeLibraryBuilder(builder.ComponentOpenSSL, *openSSLVersion, *openSSLStatic)
-	libreSSLBuilder := builder.MakeLibraryBuilder(builder.ComponentLibreSSL, *libreSSLVersion, *libreSSLStatic)
-	zlibBuilder := builder.MakeLibraryBuilder(builder.ComponentZlib, *zlibVersion, *zlibStatic)
+	pcreBuilder := builder.MakeLibraryBuilder(builder.ComponentPcre, *pcreVersion, *dltimeout, *pcreStatic)
+	openSSLBuilder := builder.MakeLibraryBuilder(builder.ComponentOpenSSL, *openSSLVersion, *dltimeout, *openSSLStatic)
+	libreSSLBuilder := builder.MakeLibraryBuilder(builder.ComponentLibreSSL, *libreSSLVersion, *dltimeout, *libreSSLStatic)
+	zlibBuilder := builder.MakeLibraryBuilder(builder.ComponentZlib, *zlibVersion, *dltimeout, *zlibStatic)
 
 	if *idempotent {
 		builders := []builder.Builder{

--- a/option.go
+++ b/option.go
@@ -3,6 +3,7 @@ package main
 import (
 	"runtime"
 	"strconv"
+	"time"
 
 	"github.com/cubicdaiya/nginx-build/builder"
 )
@@ -11,6 +12,7 @@ type Options struct {
 	Values  map[string]OptionValue
 	Bools   map[string]OptionBool
 	Numbers map[string]OptionNumber
+	Times   map[string]OptionTime
 }
 
 type OptionValue struct {
@@ -32,11 +34,18 @@ type OptionNumber struct {
 	Default int
 }
 
+type OptionTime struct {
+	Desc    string
+	Value   *time.Duration
+	Default time.Duration
+}
+
 func makeNginxBuildOptions() Options {
 	var nginxBuildOptions Options
 	argsNumber := make(map[string]OptionNumber)
 	argsBool := make(map[string]OptionBool)
 	argsString := make(map[string]OptionValue)
+	argsTime := make(map[string]OptionTime)
 
 	argsNumber["j"] = OptionNumber{
 		Desc:    "jobs to build nginx",
@@ -132,9 +141,15 @@ func makeNginxBuildOptions() Options {
 		Default: "",
 	}
 
+	argsTime["dltimeout"] = OptionTime{
+		Desc:    "timeout for download",
+		Default: builder.DefaultDownloadTimeout,
+	}
+
 	nginxBuildOptions.Bools = argsBool
 	nginxBuildOptions.Values = argsString
 	nginxBuildOptions.Numbers = argsNumber
+	nginxBuildOptions.Times = argsTime
 
 	return nginxBuildOptions
 }
@@ -149,6 +164,9 @@ func isNginxBuildOption(k string) bool {
 	if _, ok := nginxBuildOptions.Numbers[k]; ok {
 		return true
 	}
+	if _, ok := nginxBuildOptions.Times[k]; ok {
+		return true
+	}
 	return false
 }
 
@@ -158,6 +176,9 @@ func defaultStringValue(k string) string {
 	}
 	if _, ok := nginxBuildOptions.Numbers[k]; ok {
 		return strconv.Itoa(nginxBuildOptions.Numbers[k].Default)
+	}
+	if _, ok := nginxBuildOptions.Times[k]; ok {
+		return nginxBuildOptions.Times[k].Default.String()
 	}
 	return ""
 }


### PR DESCRIPTION
nginx-build sets 900s to timeout for download components. But this value is a little bit too large. This value should be smaller and controllable.