### PR TITLE
bumped default libressl version to 3.6.1

### DIFF
--- a/builder/const.go
+++ b/builder/const.go
@@ -20,7 +20,7 @@ const (
 
 // libressl
 const (
-	LibreSSLVersion           = "3.5.3"
+	LibreSSLVersion           = "3.6.1"
 	LibreSSLDownloadURLPrefix = "https://ftp.openbsd.org/pub/OpenBSD/LibreSSL"
 )
 


### PR DESCRIPTION
https://ftp.openbsd.org/pub/OpenBSD/LibreSSL/libressl-3.6.1-relnotes.txt