### PR TITLE
support nginx-quic

### DIFF
--- a/builder/builder.go
+++ b/builder/builder.go
@@ -26,6 +26,7 @@ var (
 	libresslVersionRe  *regexp.Regexp
 	openrestyVersionRe *regexp.Regexp
 	tengineVersionRe   *regexp.Regexp
+	nginxQuicVersionRe *regexp.Regexp
 )
 
 func init() {
@@ -36,6 +37,7 @@ func init() {
 	libresslVersionRe = regexp.MustCompile(`--with-openssl=.+/libressl-(\d+\.\d+\.\d+)`)
 	openrestyVersionRe = regexp.MustCompile(`nginx version: openresty/(\d+\.\d+\.\d+\.\d+)`)
 	tengineVersionRe = regexp.MustCompile(`Tengine version: Tengine/(\d+\.\d+\.\d+)`)
+	nginxQuicVersionRe = regexp.MustCompile(`nginx version: nginx.(\d+\.\d+\.\d+)`)
 }
 
 func (builder *Builder) name() string {
@@ -55,6 +57,8 @@ func (builder *Builder) name() string {
 		name = openresty.Name(builder.Version)
 	case ComponentTengine:
 		name = "tengine"
+	case ComponentNginxQuic:
+		name = "nginx-quic"
 	default:
 		panic("invalid component")
 	}
@@ -86,6 +90,9 @@ func (builder *Builder) SourcePath() string {
 }
 
 func (builder *Builder) ArchivePath() string {
+	if builder.Component == ComponentNginxQuic {
+		return fmt.Sprintf("%s.tar.gz", builder.Version)
+	}
 	return fmt.Sprintf("%s.tar.gz", builder.SourcePath())
 }
 
@@ -139,6 +146,8 @@ func (builder *Builder) InstalledVersion() (string, error) {
 		versionRe = libresslVersionRe
 	case "tengine":
 		versionRe = tengineVersionRe
+	case "nginx-quic":
+		versionRe = nginxQuicVersionRe
 	}
 
 	m := versionRe.FindSubmatch(result)
@@ -167,6 +176,8 @@ func MakeBuilder(component int, version string) Builder {
 		builder.DownloadURLPrefix = OpenRestyDownloadURLPrefix
 	case ComponentTengine:
 		builder.DownloadURLPrefix = TengineDownloadURLPrefix
+	case ComponentNginxQuic:
+		builder.DownloadURLPrefix = NginxQuicDownloadURLPrefix
 	default:
 		panic("invalid component")
 	}

--- a/builder/const.go
+++ b/builder/const.go
@@ -42,11 +42,17 @@ const (
 	TengineDownloadURLPrefix = "https://tengine.taobao.org/download"
 )
 
+const (
+	NginxQuicVersion           = "6cf8ed15fd00"
+	NginxQuicDownloadURLPrefix = "https://hg.nginx.org/nginx-quic/archive"
+)
+
 // component enumerations
 const (
 	ComponentNginx = iota
 	ComponentOpenResty
 	ComponentTengine
+	ComponentNginxQuic
 	ComponentPcre
 	ComponentOpenSSL
 	ComponentLibreSSL

--- a/nginx-build.go
+++ b/nginx-build.go
@@ -119,6 +119,7 @@ func main() {
 	versionsPrint := nginxBuildOptions.Bools["versions"].Enabled
 	openResty := nginxBuildOptions.Bools["openresty"].Enabled
 	tengine := nginxBuildOptions.Bools["tengine"].Enabled
+	nginxQuic := nginxBuildOptions.Bools["nginx-quic"].Enabled
 	configureOnly := nginxBuildOptions.Bools["configureonly"].Enabled
 	idempotent := nginxBuildOptions.Bools["idempotent"].Enabled
 	helpAll := nginxBuildOptions.Bools["help-all"].Enabled
@@ -133,6 +134,7 @@ func main() {
 	zlibVersion := nginxBuildOptions.Values["zlibversion"].Value
 	openRestyVersion := nginxBuildOptions.Values["openrestyversion"].Value
 	tengineVersion := nginxBuildOptions.Values["tengineversion"].Value
+	nginxQuicVersion := nginxBuildOptions.Values["nginxquicversion"].Value
 	patchOption := nginxBuildOptions.Values["patch-opt"].Value
 
 	// Allow multiple flags for `--patch`
@@ -184,8 +186,8 @@ func main() {
 	command.VerboseEnabled = *verbose
 
 	var nginxBuilder builder.Builder
-	if *openResty && *tengine {
-		log.Fatal("select one between '-openresty' and '-tengine'.")
+	if (*openResty && *tengine) || (*openResty && *nginxQuic) || (*tengine && *nginxQuic) {
+		log.Fatal("select one in '-openresty', '-tengine' or '-nginx-quic'.")
 	}
 	if *openSSLStatic && *libreSSLStatic {
 		log.Fatal("select one between '-openssl' and '-libressl'.")
@@ -194,6 +196,8 @@ func main() {
 		nginxBuilder = builder.MakeBuilder(builder.ComponentOpenResty, *openRestyVersion)
 	} else if *tengine {
 		nginxBuilder = builder.MakeBuilder(builder.ComponentTengine, *tengineVersion)
+	} else if *nginxQuic {
+		nginxBuilder = builder.MakeBuilder(builder.ComponentNginxQuic, *nginxQuicVersion)
 	} else {
 		nginxBuilder = builder.MakeBuilder(builder.ComponentNginx, *version)
 	}

--- a/option.go
+++ b/option.go
@@ -73,6 +73,9 @@ func makeNginxBuildOptions() Options {
 	argsBool["tengine"] = OptionBool{
 		Desc: "download tengine instead of nginx",
 	}
+	argsBool["nginx-quic"] = OptionBool{
+		Desc: "download nginx-quic instead of nginx",
+	}
 	argsBool["configureonly"] = OptionBool{
 		Desc: "configure nginx only not building",
 	}
@@ -122,6 +125,10 @@ func makeNginxBuildOptions() Options {
 	argsString["tengineversion"] = OptionValue{
 		Desc:    "tengine version",
 		Default: builder.TengineVersion,
+	}
+	argsString["nginxquicversion"] = OptionValue{
+		Desc:    "nginx-quic version",
+		Default: builder.NginxQuicVersion,
 	}
 	argsString["patch"] = OptionValue{
 		Desc:    "patch path for applying to nginx",


### PR DESCRIPTION
nginx-quic requires the BoringSSL API. The current nginx-build can use LibreSSL 3.6.0 or higher.
cf: https://hg.nginx.org/nginx-quic

In progress. We need to set `-c` as follows.

```
#!/bin/bash

./auto/configure
```