### PR TITLE
automated updates using Renovate

### DIFF
--- a/builder/const.go
+++ b/builder/const.go
@@ -20,12 +20,14 @@ const (
 
 // libressl
 const (
+	// datasource=github-tags depName=libressl/portable
 	LibreSSLVersion           = "3.6.1"
 	LibreSSLDownloadURLPrefix = "https://ftp.openbsd.org/pub/OpenBSD/LibreSSL"
 )
 
 // zlib
 const (
+	// datasource=github-tags depName=madler/zlib
 	ZlibVersion           = "1.3"
 	ZlibDownloadURLPrefix = "https://zlib.net"
 )

--- a/renovate.json
+++ b/renovate.json
@@ -2,5 +2,32 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:base"
+  ],
+  "regexManagers": [
+    {
+      "fileMatch": [
+        "builder/const.go"
+      ],
+      "extractVersionTemplate": "^v(?<version>.*)$",
+      "matchStrings": [
+        "datasource=(?<datasource>.*?) depName=(?<depName>.*?)( versioning=(?<versioning>.*?))?\n.* \"(?<currentValue>[0-9.]*)\""
+      ],
+      "versioningTemplate": "{{#if versioning}}{{versioning}}{{else}}semver{{/if}}"
+    },
+    {
+      "fileMatch": [
+        "builder/const.go"
+      ],
+      "extractVersionTemplate": "^pcre2-(?<version>.*)$",
+      "datasourceTemplate": "github-tags",
+      "depNameTemplate": "PCRE2Project/pcre2",
+      "matchStrings": [
+        "PcreVersion\\s+=\\s\"(?<currentValue>[0-9.]*)\""
+      ]
+    }
+  ],
+  "postUpdateOptions": [
+    "gomodTidy",
+    "gomodUpdateImportPaths"
   ]
 }


### PR DESCRIPTION
This commit introduces automated updates using Renovate. It includes the handling of updates not only for LibreSSL, zlib, and pcre, but also for other libraries and GitHub Actions as needed. This aims to keep our project up-to-date with the latest security patches and features.