### PR TITLE
using http in `ftp.openbsd.org`

### DIFF
--- a/builder/const.go
+++ b/builder/const.go
@@ -21,7 +21,7 @@ const (
 // libressl
 const (
 	LibreSSLVersion           = "3.6.1"
-	LibreSSLDownloadURLPrefix = "https://ftp.openbsd.org/pub/OpenBSD/LibreSSL"
+	LibreSSLDownloadURLPrefix = "http://ftp.openbsd.org/pub/OpenBSD/LibreSSL"
 )
 
 // zlib


### PR DESCRIPTION
change http from https to `ftp.openbsd.org/pub/OpenBSD/`

`https://ftp.openbsd.org` is broken.