### PR TITLE
bumped default zlib version to 1.3

### DIFF
--- a/builder/const.go
+++ b/builder/const.go
@@ -26,7 +26,7 @@ const (
 
 // zlib
 const (
-	ZlibVersion           = "1.2.13"
+	ZlibVersion           = "1.3"
 	ZlibDownloadURLPrefix = "https://zlib.net"
 )
 


### PR DESCRIPTION
I used this, but version 1.2.13 of zlib was not available.

cf: https://madler.net/pipermail/zlib-announce_madler.net/2023/000014.html