### PR TITLE
Bump default versions

### DIFF
--- a/builder/const.go
+++ b/builder/const.go
@@ -2,7 +2,7 @@ package builder
 
 // nginx
 const (
-	NginxVersion           = "1.22.1"
+	NginxVersion           = "1.24.0"
 	NginxDownloadURLPrefix = "https://nginx.org/download"
 )
 

--- a/builder/const.go
+++ b/builder/const.go
@@ -20,7 +20,7 @@ const (
 
 // libressl
 const (
-	LibreSSLVersion           = "3.6.1"
+	LibreSSLVersion           = "3.8.2"
 	LibreSSLDownloadURLPrefix = "https://ftp.openbsd.org/pub/OpenBSD/LibreSSL"
 )
 

--- a/builder/const.go
+++ b/builder/const.go
@@ -14,7 +14,7 @@ const (
 
 // openssl
 const (
-	OpenSSLVersion           = "1.1.1t"
+	OpenSSLVersion           = "3.2.0"
 	OpenSSLDownloadURLPrefix = "https://www.openssl.org/source"
 )
 


### PR DESCRIPTION
- nginx
  - 1.22.1 -> 1.24.0
- openssl
  - 1.1.1t -> 3.2.0
- libressl
  - 3.6.1 -> 3.8.2
