### PR TITLE
[renovate] Skip LibreSSL releases with patch 0

### DIFF
--- a/builder/const.go
+++ b/builder/const.go
@@ -20,7 +20,6 @@ const (
 
 // libressl
 const (
-	// datasource=github-tags depName=libressl/portable
 	LibreSSLVersion           = "3.8.2"
 	LibreSSLDownloadURLPrefix = "https://ftp.openbsd.org/pub/OpenBSD/LibreSSL"
 )

--- a/renovate.json
+++ b/renovate.json
@@ -62,6 +62,17 @@
       "fileMatch": [
         "builder/const.go"
       ],
+      "extractVersionTemplate": "^v(?<version>[0-9]*.[0-9]*.[1-9]+[0-9]*)$",
+      "datasourceTemplate": "github-tags",
+      "depNameTemplate": "libressl/portable",
+      "matchStrings": [
+        "LibreSSLVersion\\s+=\\s\"(?<currentValue>[0-9.]*)\""
+      ]
+    },
+    {
+      "fileMatch": [
+        "builder/const.go"
+      ],
       "extractVersionTemplate": "^openssl-(?<version>.*)$",
       "datasourceTemplate": "github-tags",
       "depNameTemplate": "openssl/openssl",


### PR DESCRIPTION
We changed how we look at LibreSSL releases. Now, if the patch number is 0, we don't use it. These are testing releases. This helps us only focus on stable or important releases.