### PR TITLE
Update version of freenginx extraction regex pattern in renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -29,7 +29,7 @@
       "fileMatch": [
         "builder/const.go"
       ],
-      "extractVersionTemplate": "^release-(?<version>[0-9]*.[0-9]*.[0-9]*)$",
+      "extractVersionTemplate": "^release-(?<version>[0-9]*.[0-9]*[02468].[0-9]*)$",
       "datasourceTemplate": "github-tags",
       "depNameTemplate": "freenginx-mirror/nginx",
       "matchStrings": [


### PR DESCRIPTION
This pull request includes a modification to the `renovate.json` file. The change updates the `extractVersionTemplate` regex to only match even minor version numbers in the release tag.