### PR TITLE
Update depNameTemplate to "freenginx/nginx".

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -31,7 +31,7 @@
       ],
       "extractVersionTemplate": "^release-(?<version>[0-9]*.[0-9]*[02468].[0-9]*)$",
       "datasourceTemplate": "github-tags",
-      "depNameTemplate": "freenginx-mirror/nginx",
+      "depNameTemplate": "freenginx/nginx",
       "matchStrings": [
         "FreenginxVersion\\s+=\\s\"(?<currentValue>[0-9.]*)\""
       ]


### PR DESCRIPTION
This pull request includes a minor change to the `renovate.json` file. The `depNameTemplate` value has been updated from `freenginx-mirror/nginx` to `freenginx/nginx`. This change updates the dependency name template used by Renovate bot for tracking updates.