### PR TITLE
Update Go version to 1.22.x in workflows

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -10,7 +10,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: 1.21.x
+          go-version: 1.22.x
 
       - name: Build
         run: make

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: 1.21.x
+          go-version: 1.22.x
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v5
         with:


### PR DESCRIPTION
This pull request includes updates to the Go version used in the GitHub Actions workflows. The changes are made in two different workflow files: `go.yml` and `release.yml`. Both files have been updated to use Go version `1.22.x` instead of `1.21.x`.

Updates to Go version:

* [`.github/workflows/go.yml`](diffhunk://#diff-678682767f2477de3e3c546746f8568b9a1942b2c647d32331d7e774b8ff8d9fL13-R13): Updated the Go version used in the `Set up Go` action from `1.21.x` to `1.22.x`.
* [`.github/workflows/release.yml`](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L15-R15): Updated the Go version used in the `Setup Go` action from `1.21.x` to `1.22.x`.