### PR TITLE
Update Go version to 1.22.4 in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: 1.22.x
+          go-version: 1.22.4
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v6
         with:


### PR DESCRIPTION
This pull request includes a small but important change to the `release.yml` file in the `.github/workflows` directory. The change specifically updates the Go version used in the setup from a wildcard version (1.22.x) to a specific version (1.22.4) to ensure consistent builds.