### PR TITLE
Update goreleaser action to use --clean instead of --rm-dist

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,6 +17,6 @@ jobs:
         uses: goreleaser/goreleaser-action@v6
         with:
           version: latest
-          args: release --rm-dist
+          args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This pull request includes a change to the `.github/workflows/release.yml` file. The `args` option in the `goreleaser/goreleaser-action` has been updated from `release --rm-dist` to `release --clean`. This change modifies the command-line arguments passed to the GoReleaser action in the GitHub workflow, replacing the `--rm-dist` flag with the `--clean` flag.