### PR TITLE
Add openresty support in GitHub Actions workflow

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -24,3 +24,4 @@ jobs:
           ./nginx-build -c ./config/configure.example -m ./config/modules.json.example -d work -clear -pcre -zlib -openssl
           ./nginx-build -c ./config/configure.example -m ./config/modules.json.example -d work -clear -pcre -zlib -libressl
           ./nginx-build -c ./config/configure.example -m ./config/modules.json.example -d work -clear -freenginx -pcre -zlib -openssl
+          ./nginx-build -c ./config/configure.example -m ./config/modules.json.example -d work -clear -openresty -pcre -zlib -openssl


### PR DESCRIPTION
This pull request includes a modification to the `.github/workflows/go.yml` file. The change adds a new build configuration for the Nginx server using the OpenResty module. Specifically, a new `./nginx-build` command has been added to the `jobs:` section, which includes the `-openresty` flag to enable the OpenResty module during the build process.