### PR TITLE
Add golang-version regex manager for GitHub workflows in renovate.json

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -6,6 +6,26 @@
   "regexManagers": [
     {
       "fileMatch": [
+        ".github/workflows/security.yml"
+      ],
+      "datasourceTemplate": "golang-version",
+      "depNameTemplate": "golang",
+      "matchStrings": [
+        "go-version-input: (?<currentValue>[0-9]*.[0-9]*.[0-9]*)"
+      ]
+    },
+    {
+      "fileMatch": [
+        ".github/workflows/release.yml"
+      ],
+      "datasourceTemplate": "golang-version",
+      "depNameTemplate": "golang",
+      "matchStrings": [
+        "go-version: (?<currentValue>[0-9]*.[0-9]*.[0-9]*)"
+      ]
+    },
+    {
+      "fileMatch": [
         "builder/const.go"
       ],
       "extractVersionTemplate": "^v(?<version>.*)$",


### PR DESCRIPTION
This pull request includes a change to the `renovate.json` file to add a new regex manager for managing the Go version in GitHub workflows.

Configuration updates:

* [`renovate.json`](diffhunk://#diff-7b5c8955fc544a11b4b74eddb4115f9cc51c9cf162dbffa60d37eeed82a55a57R7-R16): Added a new regex manager to manage the Go version in `.github/workflows/release.yml` using the `golang-version` datasource.