### PR TITLE
Update Go version from 1.22.x to 1.23.x in GitHub Actions workflow

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -10,7 +10,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: 1.22.x
+          go-version: 1.23.x
 
       - name: Build
         run: make


### PR DESCRIPTION
This pull request includes an update to the Go version in the GitHub Actions workflow file to ensure compatibility with the latest Go features and improvements.

* [`.github/workflows/go.yml`](diffhunk://#diff-678682767f2477de3e3c546746f8568b9a1942b2c647d32331d7e774b8ff8d9fL13-R13): Updated Go version from `1.22.x` to `1.23.x` to utilize the latest features and improvements in Go.