### PR TITLE
Update OpenSSL download URL to GitHub releases

### DIFF
--- a/builder/builder.go
+++ b/builder/builder.go
@@ -158,7 +158,7 @@ func MakeBuilder(component int, version string) Builder {
 	case ComponentPcre:
 		builder.DownloadURLPrefix = fmt.Sprintf("%s/pcre2-%s", PcreDownloadURLPrefix, version)
 	case ComponentOpenSSL:
-		builder.DownloadURLPrefix = OpenSSLDownloadURLPrefix
+		builder.DownloadURLPrefix = fmt.Sprintf("%s/openssl-%s", OpenSSLDownloadURLPrefix, version)
 	case ComponentLibreSSL:
 		builder.DownloadURLPrefix = LibreSSLDownloadURLPrefix
 	case ComponentZlib:

--- a/builder/builder_test.go
+++ b/builder/builder_test.go
@@ -110,7 +110,7 @@ func TestDownloadURL(t *testing.T) {
 		},
 		{
 			got:  builders[ComponentOpenSSL].DownloadURL(),
-			want: fmt.Sprintf("%s/openssl-%s.tar.gz", OpenSSLDownloadURLPrefix, OpenSSLVersion),
+			want: fmt.Sprintf("%s/openssl-%s/openssl-%s.tar.gz", OpenSSLDownloadURLPrefix, OpenSSLVersion, OpenSSLVersion),
 		},
 		{
 			got:  builders[ComponentLibreSSL].DownloadURL(),

--- a/builder/const.go
+++ b/builder/const.go
@@ -15,7 +15,7 @@ const (
 // openssl
 const (
 	OpenSSLVersion           = "3.3.1"
-	OpenSSLDownloadURLPrefix = "https://www.openssl.org/source"
+	OpenSSLDownloadURLPrefix = "https://github.com/openssl/openssl/releases/download"
 )
 
 // libressl


### PR DESCRIPTION
This pull request includes changes to the `builder` package to update the URL structure for downloading OpenSSL. The most important changes include modifying the URL format in the `MakeBuilder` function, updating the corresponding test cases, and changing the OpenSSL download URL prefix.

### Updates to OpenSSL URL structure:

* [`builder/builder.go`](diffhunk://#diff-d371e466d16c4d92dff29b2806e847c619149cd6de147f1cb9ae7e9511d5da7fL161-R161): Modified the `MakeBuilder` function to include the OpenSSL version in the `DownloadURLPrefix` format. (`[builder/builder.goL161-R161](diffhunk://#diff-d371e466d16c4d92dff29b2806e847c619149cd6de147f1cb9ae7e9511d5da7fL161-R161)`)
* [`builder/builder_test.go`](diffhunk://#diff-0b6515a22d5e5673e7fad3d1f3576a7b89aa6ee7f38aa7c583c12f4a63a0a4feL113-R113): Updated the `TestDownloadURL` test case to reflect the new URL format for OpenSSL. (`[builder/builder_test.goL113-R113](diffhunk://#diff-0b6515a22d5e5673e7fad3d1f3576a7b89aa6ee7f38aa7c583c12f4a63a0a4feL113-R113)`)
* [`builder/const.go`](diffhunk://#diff-df8a40b36330190dbbca89642040400981eaea7d0a3e94ce641f882854b2d8b5L18-R18): Changed the `OpenSSLDownloadURLPrefix` to the new GitHub releases URL. (`[builder/const.goL18-R18](diffhunk://#diff-df8a40b36330190dbbca89642040400981eaea7d0a3e94ce641f882854b2d8b5L18-R18)`)