### PR TITLE
Update copyright year in LICENSE and message.go from 2022 to 2014

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2014-2022 Tatsuhiko Kubo <cubicdaiya@gmail.com>
+Copyright (c) 2014- Tatsuhiko Kubo <cubicdaiya@gmail.com>
 
 MIT License
 

--- a/message.go
+++ b/message.go
@@ -28,7 +28,7 @@ func nginxBuildVersion() string {
 func printNginxBuildVersion() {
 	fmt.Printf(`nginx-build %s
 Compiler: %s %s
-Copyright (C) 2014-2022 Tatsuhiko Kubo <cubicdaiya@gmail.com>
+Copyright (C) 2014- Tatsuhiko Kubo <cubicdaiya@gmail.com>
 `,
 		nginxBuildVersion(),
 		runtime.Compiler,


### PR DESCRIPTION
This pull request includes updates to the copyright year in the `LICENSE` and `message.go` files.

* [`LICENSE`](diffhunk://#diff-c693279643b8cd5d248172d9c22cb7cf4ed163a3c98c8a3f69c2717edd3eacb7L1-R1): Updated the copyright year to remove the end year.
* [`message.go`](diffhunk://#diff-2ce052ca28a77c3b54be26bfc568dddef91bf239253d0ad537609af1731032d4L31-R31): Updated the copyright year in the `printNginxBuildVersion` function.