### PR TITLE
Update OpenResty version to 1.27.1.1 and add CI

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -24,3 +24,4 @@ jobs:
           ./nginx-build -c ./config/configure.example -m ./config/modules.json.example -d work -clear -pcre -zlib -openssl
           ./nginx-build -c ./config/configure.example -m ./config/modules.json.example -d work -clear -pcre -zlib -libressl
           ./nginx-build -c ./config/configure.example -m ./config/modules.json.example -d work -clear -freenginx -pcre -zlib -openssl
+          ./nginx-build -c ./config/configure.example -m ./config/modules.json.example -d work -clear -openresty -pcre -zlib -openssl

--- a/builder/const.go
+++ b/builder/const.go
@@ -32,7 +32,7 @@ const (
 
 // openResty
 const (
-	OpenRestyVersion           = "1.25.3.2"
+	OpenRestyVersion           = "1.27.1.1"
 	OpenRestyDownloadURLPrefix = "https://openresty.org/download"
 )
 


### PR DESCRIPTION
This pull request includes updates to the `go.yml` workflow and the `const.go` file to support a new version of OpenResty and add a new build configuration.

Workflow updates:

* [`.github/workflows/go.yml`](diffhunk://#diff-678682767f2477de3e3c546746f8568b9a1942b2c647d32331d7e774b8ff8d9fR27): Added a new build configuration for OpenResty. (`[.github/workflows/go.ymlR27](diffhunk://#diff-678682767f2477de3e3c546746f8568b9a1942b2c647d32331d7e774b8ff8d9fR27)`)

Version updates:

* [`builder/const.go`](diffhunk://#diff-df8a40b36330190dbbca89642040400981eaea7d0a3e94ce641f882854b2d8b5L35-R35): Updated the OpenResty version from `1.25.3.2` to `1.27.1.1`. (`[builder/const.goL35-R35](diffhunk://#diff-df8a40b36330190dbbca89642040400981eaea7d0a3e94ce641f882854b2d8b5L35-R35)`)