### PR TITLE
Update version extraction regex for LibreSSL

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -82,7 +82,7 @@
       "fileMatch": [
         "builder/const.go"
       ],
-      "extractVersionTemplate": "^v(?<version>[0-9]*.[0-9]*.[1-9]+[0-9]*)$",
+      "extractVersionTemplate": "^v(?<version>[0-9]*.[0-9]*.[0-9]*)$",
       "datasourceTemplate": "github-tags",
       "depNameTemplate": "libressl/portable",
       "matchStrings": [


### PR DESCRIPTION
This pull request includes a small change to the `renovate.json` file. The change modifies the `extractVersionTemplate` to correctly match versions with any number of digits in the patch version.

* [`renovate.json`](diffhunk://#diff-7b5c8955fc544a11b4b74eddb4115f9cc51c9cf162dbffa60d37eeed82a55a57L85-R85): Updated `extractVersionTemplate` to match versions with any number of digits in the patch version.