### PR TITLE
Add multiple Nginx build jobs

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,27 +1,69 @@
 name: Go
 
 on: [push]
+
 jobs:
   build:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
           go-version: 1.23.x
-
       - name: Build
         run: make
-
       - name: Test
         run: make check
 
-      - name: Run
+  run-nginx-openssl:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: 1.23.x
+      - name: Run Nginx with OpenSSL
         run: |
           make
           ./nginx-build -c ./config/configure.example -m ./config/modules.json.example -d work -clear -pcre -zlib -openssl
+
+  run-nginx-libressl:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: 1.23.x
+      - name: Run Nginx with LibreSSL
+        run: |
+          make
           ./nginx-build -c ./config/configure.example -m ./config/modules.json.example -d work -clear -pcre -zlib -libressl
+
+  run-freenginx:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: 1.23.x
+      - name: Run Nginx with FreeNginx
+        run: |
+          make
           ./nginx-build -c ./config/configure.example -m ./config/modules.json.example -d work -clear -freenginx -pcre -zlib -openssl
+
+  run-openresty:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: 1.23.x
+      - name: Run Nginx with OpenResty
+        run: |
+          make
           ./nginx-build -c ./config/configure.example -m ./config/modules.json.example -d work -clear -openresty -pcre -zlib -openssl


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow for the Go project to include additional jobs for running Nginx with different SSL libraries. The most important changes include the addition of new jobs for running Nginx with OpenSSL, LibreSSL, FreeNginx, and OpenResty.

Enhancements to GitHub Actions workflow:

* [`.github/workflows/go.yml`](diffhunk://#diff-678682767f2477de3e3c546746f8568b9a1942b2c647d32331d7e774b8ff8d9fR4-R68): Added a new job `run-nginx-openssl` to run Nginx with OpenSSL.
* [`.github/workflows/go.yml`](diffhunk://#diff-678682767f2477de3e3c546746f8568b9a1942b2c647d32331d7e774b8ff8d9fR4-R68): Added a new job `run-nginx-libressl` to run Nginx with LibreSSL.
* [`.github/workflows/go.yml`](diffhunk://#diff-678682767f2477de3e3c546746f8568b9a1942b2c647d32331d7e774b8ff8d9fR4-R68): Added a new job `run-freenginx` to run Nginx with FreeNginx.
* [`.github/workflows/go.yml`](diffhunk://#diff-678682767f2477de3e3c546746f8568b9a1942b2c647d32331d7e774b8ff8d9fR4-R68): Added a new job `run-openresty` to run Nginx with OpenResty.