### PR TITLE
Add error handling for non-200 status codes in download function.

### DIFF
--- a/download.go
+++ b/download.go
@@ -29,6 +29,10 @@ func download(b *builder.Builder) error {
 	}
 	defer res.Body.Close()
 
+	if res.StatusCode != http.StatusOK {
+		return fmt.Errorf("failed to download %s. %s", b.DownloadURL(), res.Status)
+	}
+
 	tmpFileName := b.ArchivePath() + ".download"
 	f, err := os.Create(tmpFileName)
 	if err != nil {


### PR DESCRIPTION
This pull request includes a change to the `download.go` file to improve error handling during the download process.

Error handling improvement:

* [`download.go`](diffhunk://#diff-185eea976fbefe704cffdd8264c8acb8748cf6a078a08b9b8790623721422352R32-R35): Added a check for the HTTP status code to ensure it is `http.StatusOK` before proceeding with the download. If the status code is not `http.StatusOK`, the function returns an error with a descriptive message.