### PR TITLE
update extractVersionTemplate regex to match version format correctly

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -71,7 +71,7 @@
       "fileMatch": [
         "builder/const.go"
       ],
-      "extractVersionTemplate": "^pcre2-(?<version>.*)$",
+      "extractVersionTemplate": "^pcre2-(?<version>[0-9]*\\.[0-9]*)$",
       "datasourceTemplate": "github-tags",
       "depNameTemplate": "PCRE2Project/pcre2",
       "matchStrings": [


### PR DESCRIPTION
This pull request includes a small change to the `renovate.json` file. The change updates the `extractVersionTemplate` to ensure that only numerical versions are matched.