### PR TITLE
Update Go version from 1.23.x to 1.24.1 in GitHub workflows

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -10,7 +10,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: 1.23.x
+          go-version: 1.24.1
       - name: Build
         run: make
       - name: Test
@@ -23,7 +23,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: 1.23.x
+          go-version: 1.24.1
       - name: Run Nginx with OpenSSL
         run: |
           make
@@ -36,7 +36,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: 1.23.x
+          go-version: 1.24.1
       - name: Run Nginx with LibreSSL
         run: |
           make
@@ -49,7 +49,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: 1.23.x
+          go-version: 1.24.1
       - name: Run Nginx with FreeNginx
         run: |
           make
@@ -62,7 +62,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: 1.23.x
+          go-version: 1.24.1
       - name: Run Nginx with OpenResty
         run: |
           make


### PR DESCRIPTION
This pull request includes updates to the Go version used in the GitHub Actions workflow configuration. The changes ensure that the workflow uses a more recent version of Go.

Updates to Go version in GitHub Actions workflow:

* [`.github/workflows/go.yml`](diffhunk://#diff-678682767f2477de3e3c546746f8568b9a1942b2c647d32331d7e774b8ff8d9fL13-R13): Updated `go-version` from `1.23.x` to `1.24.1` in multiple steps. [[1]](diffhunk://#diff-678682767f2477de3e3c546746f8568b9a1942b2c647d32331d7e774b8ff8d9fL13-R13) [[2]](diffhunk://#diff-678682767f2477de3e3c546746f8568b9a1942b2c647d32331d7e774b8ff8d9fL26-R26) [[3]](diffhunk://#diff-678682767f2477de3e3c546746f8568b9a1942b2c647d32331d7e774b8ff8d9fL39-R39) [[4]](diffhunk://#diff-678682767f2477de3e3c546746f8568b9a1942b2c647d32331d7e774b8ff8d9fL52-R52) [[5]](diffhunk://#diff-678682767f2477de3e3c546746f8568b9a1942b2c647d32331d7e774b8ff8d9fL65-R65)