### PR TITLE
fix: close file after loading module configuration

### DIFF
--- a/module3rd/load.go
+++ b/module3rd/load.go
@@ -13,6 +13,7 @@ func Load(path string) ([]Module3rd, error) {
 		if err != nil {
 			return modules, err
 		}
+		defer f.Close()
 		if err := json.NewDecoder(f).Decode(&modules); err != nil {
 			return modules, fmt.Errorf("modulesConfPath(%s) is invalid JSON.", path)
 		}


### PR DESCRIPTION
This pull request includes a small but important change to the `Load` function in `module3rd/load.go`. The change ensures that the file handle (`f`) is properly closed after use by adding a `defer f.Close()` statement.