### PR TITLE
Improve error handling and logging

### DIFF
--- a/builder/nginx.go
+++ b/builder/nginx.go
@@ -2,6 +2,8 @@ package builder
 
 import (
 	"bufio"
+	"fmt"
+	"log"
 	"os"
 	"strconv"
 
@@ -16,6 +18,7 @@ func BuildNginx(jobs int) error {
 
 	f, err := os.Create("nginx-build.log")
 	if err != nil {
+		log.Printf("[warn] could not create nginx-build.log: %v", err)
 		return command.Run(args)
 	}
 	defer f.Close()
@@ -28,7 +31,11 @@ func BuildNginx(jobs int) error {
 	cmd.Stderr = writer
 	defer writer.Flush()
 
-	return cmd.Run()
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("make failed: %w", err)
+	}
+
+	return nil
 }
 
 func IsSameVersion(builders []Builder) (bool, error) {

--- a/configure/configure.go
+++ b/configure/configure.go
@@ -2,6 +2,8 @@ package configure
 
 import (
 	"bufio"
+	"fmt"
+	"log"
 	"os"
 
 	"github.com/cubicdaiya/nginx-build/command"
@@ -15,6 +17,7 @@ func Run() error {
 
 	f, err := os.Create("nginx-configure.log")
 	if err != nil {
+		log.Printf("[warn] could not create nginx-configure.log: %v", err)
 		return command.Run(args)
 	}
 	defer f.Close()
@@ -28,5 +31,9 @@ func Run() error {
 	cmd.Stdout = writer
 	defer writer.Flush()
 
-	return cmd.Run()
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("configure failed: %w", err)
+	}
+
+	return nil
 }

--- a/module3rd/provide.go
+++ b/module3rd/provide.go
@@ -13,24 +13,34 @@ import (
 func Provide(m *Module3rd) error {
 	if len(m.Rev) > 0 {
 		dir := util.SaveCurrentDir()
-		os.Chdir(m.Name)
+		if err := os.Chdir(m.Name); err != nil {
+			return fmt.Errorf("chdir to %s failed: %w", m.Name, err)
+		}
 		if err := switchRev(m.Form, m.Rev); err != nil {
 			return fmt.Errorf("%s (%s checkout %s): %s", m.Name, m.Form, m.Rev, err.Error())
 		}
-		os.Chdir(dir)
+		if err := os.Chdir(dir); err != nil {
+			return fmt.Errorf("return to dir %s failed: %w", dir, err)
+		}
 	}
 
 	if len(m.Shprov) > 0 {
 		dir := util.SaveCurrentDir()
 		if len(m.ShprovDir) > 0 {
-			os.Chdir(m.Name + "/" + m.ShprovDir)
+			if err := os.Chdir(m.Name + "/" + m.ShprovDir); err != nil {
+				return fmt.Errorf("chdir to %s/%s failed: %w", m.Name, m.ShprovDir, err)
+			}
 		} else {
-			os.Chdir(m.Name)
+			if err := os.Chdir(m.Name); err != nil {
+				return fmt.Errorf("chdir to %s failed: %w", m.Name, err)
+			}
 		}
 		if err := provideShell(m.Shprov); err != nil {
 			return fmt.Errorf("%s's shprov(%s): %s", m.Name, m.Shprov, err.Error())
 		}
-		os.Chdir(dir)
+		if err := os.Chdir(dir); err != nil {
+			return fmt.Errorf("return to dir %s failed: %w", dir, err)
+		}
 	}
 
 	return nil

--- a/nginx-build.go
+++ b/nginx-build.go
@@ -347,7 +347,9 @@ func main() {
 	}
 
 	// cd workDir/nginx-${version}
-	os.Chdir(nginxBuilder.SourcePath())
+	if err := os.Chdir(nginxBuilder.SourcePath()); err != nil {
+		log.Fatalf("failed to change directory: %v", err)
+	}
 
 	var dependencies []builder.StaticLibrary
 	if *pcreStatic {


### PR DESCRIPTION
This pull request improves error handling and logging across multiple files in the codebase. The changes ensure that errors are logged with detailed messages and are wrapped with context for better debugging. Additionally, it replaces direct calls to `os.Chdir` with error-checked calls to prevent silent failures.

### Enhanced Error Handling:

* [`builder/nginx.go`](diffhunk://#diff-8c56041a4f5040e13143a95f4c423cc774265df7c0749dc89ce8bf89f4665eb4R21): Updated `cmd.Run()` calls to return wrapped errors with context using `fmt.Errorf`. Added error checks for `os.Create` and improved logging when creating `nginx-build.log`. [[1]](diffhunk://#diff-8c56041a4f5040e13143a95f4c423cc774265df7c0749dc89ce8bf89f4665eb4R21) [[2]](diffhunk://#diff-8c56041a4f5040e13143a95f4c423cc774265df7c0749dc89ce8bf89f4665eb4L31-R38)
* [`configure/configure.go`](diffhunk://#diff-18045263cf1d44988f4dd217ec5f7812e16dfa241d0e180000cc20edd76315b7R20): Similar updates to `cmd.Run()` calls and error handling for `os.Create` when creating `nginx-configure.log`. [[1]](diffhunk://#diff-18045263cf1d44988f4dd217ec5f7812e16dfa241d0e180000cc20edd76315b7R20) [[2]](diffhunk://#diff-18045263cf1d44988f4dd217ec5f7812e16dfa241d0e180000cc20edd76315b7L31-R38)
* [`module3rd/provide.go`](diffhunk://#diff-cf6ce16e0eee2df80db32e8a3a7b762a345151db0e374854f7739a3c7d7a34cdL16-R43): Replaced direct `os.Chdir` calls with error-checked versions and added detailed error messages for directory changes.

### Improved Logging:

* `builder/nginx.go` and `configure/configure.go`: Added `log.Printf` statements to warn about issues when creating log files. [[1]](diffhunk://#diff-8c56041a4f5040e13143a95f4c423cc774265df7c0749dc89ce8bf89f4665eb4R21) [[2]](diffhunk://#diff-18045263cf1d44988f4dd217ec5f7812e16dfa241d0e180000cc20edd76315b7R20)
* [`nginx-build.go`](diffhunk://#diff-667ffbacfd12ee2bb5af7dbbab9564ac510094328149f2d02b25bca5b94c6492L350-R352): Added `log.Fatalf` for critical errors during directory changes in the `main` function.