### PR TITLE
trigger workflow on pull_request instead of push event

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,6 +1,7 @@
 name: Go
 
-on: [push]
+on:
+  pull_request:
 
 jobs:
   build:


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow for Go projects to trigger on pull requests instead of just pushes. 

Key change:

* [`.github/workflows/go.yml`](diffhunk://#diff-678682767f2477de3e3c546746f8568b9a1942b2c647d32331d7e774b8ff8d9fL3-R4): Modified the `on` configuration to include `pull_request`, ensuring the workflow runs when a pull request is created or updated.