### PR TITLE
Fix typo in comment

### DIFF
--- a/nginx-build.go
+++ b/nginx-build.go
@@ -277,7 +277,7 @@ func main() {
 		log.Fatal(err)
 	}
 
-	// remove nginx source code applyed patch
+	// remove nginx source code applied patch
 	if *patchPath != "" && util.FileExists(nginxBuilder.SourcePath()) {
 		err := os.RemoveAll(nginxBuilder.SourcePath())
 		if err != nil {


### PR DESCRIPTION
This pull request includes a minor typo correction in a comment within the `nginx-build.go` file. The word "applyed" was corrected to "applied" for clarity.