### PR TITLE
Simplify directory creation errors

### DIFF
--- a/nginx-build.go
+++ b/nginx-build.go
@@ -244,7 +244,7 @@ func main() {
 	if !util.FileExists(*workParentDir) {
 		err := os.Mkdir(*workParentDir, 0755)
 		if err != nil {
-			log.Fatalf("Failed to create working directory(%s) does not exist.", *workParentDir)
+			log.Fatalf("Failed to create working directory %s.", *workParentDir)
 		}
 	}
 
@@ -267,7 +267,7 @@ func main() {
 	if !util.FileExists(workDir) {
 		err := os.MkdirAll(workDir, 0755)
 		if err != nil {
-			log.Fatalf("Failed to create working directory(%s) does not exist.", workDir)
+			log.Fatalf("Failed to create working directory %s.", workDir)
 		}
 	}
 


### PR DESCRIPTION
This pull request includes minor changes to improve error message clarity in the `nginx-build.go` file. The changes simplify the wording of log messages when a working directory cannot be created.

Error message improvements:

* [`nginx-build.go`](diffhunk://#diff-667ffbacfd12ee2bb5af7dbbab9564ac510094328149f2d02b25bca5b94c6492L247-R247): Updated log messages in `func main()` to remove redundant phrasing and improve readability when reporting failure to create a working directory. [[1]](diffhunk://#diff-667ffbacfd12ee2bb5af7dbbab9564ac510094328149f2d02b25bca5b94c6492L247-R247) [[2]](diffhunk://#diff-667ffbacfd12ee2bb5af7dbbab9564ac510094328149f2d02b25bca5b94c6492L270-R270)