### PR TITLE
Add actions language to CodeQL analysis matrix in workflow YAML

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -40,7 +40,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        language: ["go"]
+        language: ["go", "actions"]
         # CodeQL supports [ 'c-cpp', 'csharp', 'go', 'java-kotlin', 'javascript-typescript', 'python', 'ruby', 'swift' ]
         # Use only 'java-kotlin' to analyze code written in Java, Kotlin or both
         # Use only 'javascript-typescript' to analyze code written in JavaScript, TypeScript or both


### PR DESCRIPTION
This pull request updates the CodeQL workflow configuration to expand the set of languages analyzed during code scanning. Specifically, it adds support for analyzing GitHub Actions workflows in addition to Go code.

Enhancement to CodeQL analysis:

* [`.github/workflows/codeql.yml`](diffhunk://#diff-12783128521e452af0cfac94b99b8d250413c516ec71fe6d97dbea666ff7ba27L43-R43): Updated the `language` matrix in the CodeQL job to include `"actions"` alongside `"go"`, enabling security and quality analysis for GitHub Actions workflows as well as Go code.