### PR TITLE
Add explicit permissions for contents in GitHub workflow files

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -3,6 +3,9 @@ name: Go
 on:
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,10 @@ on:
   push:
     tags:
       - "v[0-9]+.[0-9]+.[0-9]+"
+
+permissions:
+  contents: write
+
 jobs:
   goreleaser:
     runs-on: ubuntu-latest

--- a/.github/workflows/renovate-config-validator-ci.yml
+++ b/.github/workflows/renovate-config-validator-ci.yml
@@ -7,6 +7,9 @@ on:
       - "renovate.json"
       - ".github/workflows/renovate-config-validator-ci.yml"
 
+permissions:
+  contents: read
+
 jobs:
   renovate-config-validator:
     timeout-minutes: 10

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -8,6 +8,9 @@ on:
   schedule:
     - cron: "0 0 * * *"
 
+permissions:
+  contents: read
+
 jobs:
   govulncheck_job:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This pull request updates several GitHub Actions workflow files to explicitly set the required permissions for each workflow. This helps improve security by ensuring each workflow only has the minimum permissions necessary for its tasks.

**Workflow permission updates:**

* [`.github/workflows/go.yml`](diffhunk://#diff-678682767f2477de3e3c546746f8568b9a1942b2c647d32331d7e774b8ff8d9fR6-R8): Sets `contents: read` permission to restrict the workflow to read-only access to repository contents.
* [`.github/workflows/renovate-config-validator-ci.yml`](diffhunk://#diff-e519a4bcca8b109726730f425f70681c1ebc03420db40b019c222ff042b1fd76R10-R12): Sets `contents: read` permission for the Renovate config validator workflow.
* [`.github/workflows/security.yml`](diffhunk://#diff-6102d4f2cddb56c446459bde9bf8e8044b87ce3f98a24c2bba99debfd62461dcR11-R13): Sets `contents: read` permission for the security workflow.
* [`.github/workflows/release.yml`](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34R6-R9): Sets `contents: write` permission for the release workflow, allowing it to write to repository contents as needed for releases.