### PR TITLE
Preserve trailing comments in configure script generation and loading

### DIFF
--- a/config/configure.example
+++ b/config/configure.example
@@ -3,3 +3,4 @@
 ./configure \
 --sbin-path=/usr/sbin/nginx \
 --conf-path=/etc/nginx/nginx.conf \
+# comment out

--- a/nginx-build.go
+++ b/nginx-build.go
@@ -261,7 +261,7 @@ func main() {
 	if err != nil {
 		log.Fatal(err)
 	}
-	nginxConfigure = configure.Normalize(nginxConfigure)
+	nginxConfigure, trailingComments := configure.Normalize(nginxConfigure)
 
 	modules3rd, err := module3rd.Load(*modulesConfPath)
 	if err != nil {
@@ -437,6 +437,15 @@ func main() {
 	}
 
 	configureScript := configure.Generate(nginxConfigure, modules3rd, dependencies, configureOptions, rootDir, *openResty, *jobs)
+	if trailingComments != "" {
+		if !strings.HasSuffix(configureScript, "\n") {
+			configureScript += "\n"
+		}
+		configureScript += trailingComments
+		if !strings.HasSuffix(configureScript, "\n") {
+			configureScript += "\n"
+		}
+	}
 
 	err = os.WriteFile("./nginx-configure", []byte(configureScript), 0655)
 	if err != nil {


### PR DESCRIPTION
This pull request enhances how trailing comments are handled in generated configure scripts, ensuring that any comments at the end of the input are preserved in the output. The main changes involve updating the normalization logic, the main build process, and adding a new test to verify this behavior.

**Improvements to configure script normalization and generation:**

* The `Normalize` function in `configure/normalize.go` now returns both the base configure script and any trailing comment lines, preserving comments that start with `#` at the end of the input.
* The main build logic in `nginx-build.go` is updated to append any captured trailing comments to the generated configure script, ensuring they are retained in the output file. [[1]](diffhunk://#diff-667ffbacfd12ee2bb5af7dbbab9564ac510094328149f2d02b25bca5b94c6492L264-R264) [[2]](diffhunk://#diff-667ffbacfd12ee2bb5af7dbbab9564ac510094328149f2d02b25bca5b94c6492R440-R448)

**Testing and code quality:**

* A new test `TestGeneratePreservesTrailingComments` is added to `configure/configure_test.go` to verify that trailing comments are correctly preserved and that options are appended without being commented out.

**Minor code cleanup:**

* Formatting in `normalizeAddModulePaths` is simplified by replacing `fmt.Sprintf` with string concatenation for building module paths.

**Documentation/example update:**

* A comment is added to `config/configure.example` to clarify usage.