### PR TITLE
Add path filters to workflows for targeted CI runs

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -14,8 +14,34 @@ name: "CodeQL"
 on:
   push:
     branches: ["master"]
+    paths:
+      - '**/*.go'
+      - go.mod
+      - go.sum
+      - Makefile
+      - builder/**
+      - command/**
+      - config/**
+      - configure/**
+      - module3rd/**
+      - openresty/**
+      - util/**
+      - '.github/workflows/**'
   pull_request:
     branches: ["master"]
+    paths:
+      - '**/*.go'
+      - go.mod
+      - go.sum
+      - Makefile
+      - builder/**
+      - command/**
+      - config/**
+      - configure/**
+      - module3rd/**
+      - openresty/**
+      - util/**
+      - '.github/workflows/**'
   schedule:
     - cron: "37 22 * * 0"
 

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -2,6 +2,21 @@ name: Go
 
 on:
   pull_request:
+    paths:
+      - '**/*.go'
+      - go.mod
+      - go.sum
+      - Makefile
+      - builder/**
+      - command/**
+      - config/**
+      - configure/**
+      - module3rd/**
+      - nginx-build
+      - nginx-build.go
+      - openresty/**
+      - util/**
+      - '.github/workflows/go.yml'
 
 permissions:
   contents: read

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -4,7 +4,33 @@ on:
   push:
     branches:
       - master
+    paths:
+      - '**/*.go'
+      - go.mod
+      - go.sum
+      - Makefile
+      - builder/**
+      - command/**
+      - config/**
+      - configure/**
+      - module3rd/**
+      - openresty/**
+      - util/**
+      - '.github/workflows/security.yml'
   pull_request:
+    paths:
+      - '**/*.go'
+      - go.mod
+      - go.sum
+      - Makefile
+      - builder/**
+      - command/**
+      - config/**
+      - configure/**
+      - module3rd/**
+      - openresty/**
+      - util/**
+      - '.github/workflows/security.yml'
   schedule:
     - cron: "0 0 * * *"
 


### PR DESCRIPTION
This pull request updates the workflow triggers for several GitHub Actions to make them more efficient by restricting when they run. The workflows will now only execute when relevant files or directories are changed, reducing unnecessary runs and improving CI performance.

**Workflow trigger improvements:**

* [`.github/workflows/codeql.yml`](diffhunk://#diff-12783128521e452af0cfac94b99b8d250413c516ec71fe6d97dbea666ff7ba27R17-R44): Added `paths` filters to both `push` and `pull_request` events so the CodeQL workflow only runs when Go source files, related configuration files, or workflow files are modified.
* [`.github/workflows/go.yml`](diffhunk://#diff-678682767f2477de3e3c546746f8568b9a1942b2c647d32331d7e774b8ff8d9fR5-R19): Added `paths` filters to the `pull_request` event to ensure the Go workflow only runs when Go-related files or the workflow file itself are changed.
* [`.github/workflows/security.yml`](diffhunk://#diff-6102d4f2cddb56c446459bde9bf8e8044b87ce3f98a24c2bba99debfd62461dcR7-R33): Added `paths` filters to both `push` and `pull_request` events so the Security workflow only runs when Go source files, related configuration files, or the workflow file itself are modified.