### PR TITLE
Add minimumReleaseAge of 2 days to renovate config.json

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -3,6 +3,7 @@
   "extends": [
     "config:recommended"
   ],
+  "minimumReleaseAge": "2 days",
   "customManagers": [
     {
       "customType": "regex",


### PR DESCRIPTION
This pull request introduces a configuration update to the `renovate.json` file, specifying a delay before newly released dependencies are considered for updates.

Dependency management:

* Added the `minimumReleaseAge` property set to "2 days" in `renovate.json` to ensure that only dependencies released at least two days ago are eligible for update, reducing the risk of adopting unstable new releases.