### PR TITLE
add OSV scanner workflows

### DIFF
--- a/.github/workflows/osv-scanner-pr.yml
+++ b/.github/workflows/osv-scanner-pr.yml
@@ -1,0 +1,20 @@
+name: OSV-Scanner PR Scan
+
+# Change "main" to your default branch if you use a different name, i.e. "master"
+on:
+  pull_request:
+    branches: [master]
+  merge_group:
+    branches: [master]
+
+permissions:
+  # Required to upload SARIF file to CodeQL. See: https://github.com/github/codeql-action/issues/2117
+  actions: read
+  # Require writing security events to upload SARIF file to security tab
+  security-events: write
+  # Only need to read contents
+  contents: read
+
+jobs:
+  scan-pr:
+    uses: "google/osv-scanner-action/.github/workflows/osv-scanner-reusable-pr.yml@v2.3.1"

--- a/.github/workflows/osv-scanner-scheduled.yml
+++ b/.github/workflows/osv-scanner-scheduled.yml
@@ -1,0 +1,20 @@
+name: OSV-Scanner Scheduled Scan
+
+on:
+  schedule:
+    - cron: "30 12 * * 1"
+  # Change "main" to your default branch if you use a different name, i.e. "master"
+  push:
+    branches: [master]
+
+permissions:
+  # Required to upload SARIF file to CodeQL. See: https://github.com/github/codeql-action/issues/2117
+  actions: read
+  # Require writing security events to upload SARIF file to security tab
+  security-events: write
+  # Only need to read contents
+  contents: read
+
+jobs:
+  scan-scheduled:
+    uses: "google/osv-scanner-action/.github/workflows/osv-scanner-reusable.yml@v2.3.1"

--- a/osv-scanner.toml
+++ b/osv-scanner.toml
@@ -1,0 +1,1 @@
+GoVersionOverride = "1.25.5"

--- a/renovate.json
+++ b/renovate.json
@@ -8,10 +8,21 @@
     {
       "customType": "regex",
       "managerFilePatterns": [
-        "/.github/workflows/security.yml/"
+        "/.github/workflows/go.yml/"
       ],
       "datasourceTemplate": "golang-version",
       "depNameTemplate": "golang",
+      "matchStrings": [
+        "go-version: (?<currentValue>[0-9]*.[0-9]*.[0-9]*)"
+      ]
+    },
+    {
+      "customType": "regex",
+      "managerFilePatterns": [
+        "/.github/workflows/security.yml/"
+      ],
+      "datasourceTemplate": "golang-version",
+      "depNameTemplate": "golang-security",
       "matchStrings": [
         "go-version-input: (?<currentValue>[0-9]*.[0-9]*.[0-9]*)"
       ]
@@ -25,6 +36,17 @@
       "depNameTemplate": "golang",
       "matchStrings": [
         "go-version: (?<currentValue>[0-9]*.[0-9]*.[0-9]*)"
+      ]
+    },
+    {
+      "customType": "regex",
+      "managerFilePatterns": [
+        "/osv-scanner.toml/"
+      ],
+      "datasourceTemplate": "golang-version",
+      "depNameTemplate": "golang-security",
+      "matchStrings": [
+        "GoVersionOverride = \"(?<currentValue>[0-9]*.[0-9]*.[0-9]*)\""
       ]
     },
     {
@@ -124,6 +146,12 @@
     }
   ],
   "packageRules": [
+    {
+      "matchDepNames": [
+        "golang-security"
+      ],
+      "groupName": "go-version-security"
+    },
     {
       "matchDatasources": [
         "github-tags"


### PR DESCRIPTION
This pull request introduces automated security scanning for vulnerabilities using OSV-Scanner, both on pull requests and on a scheduled basis. It also updates the Renovate configuration to ensure Go version management is consistent and automated across new and existing configuration files, including support for the new OSV-Scanner configuration.

**Security automation:**

* Added `.github/workflows/osv-scanner-pr.yml` to run OSV-Scanner on pull requests and merge groups targeting `master`, using the reusable workflow from the official OSV-Scanner GitHub Action.
* Added `.github/workflows/osv-scanner-scheduled.yml` to run OSV-Scanner weekly via a scheduled workflow and on pushes to `master`.
* Introduced `osv-scanner.toml` with a `GoVersionOverride` setting to specify the Go version used by OSV-Scanner.

**Renovate configuration improvements:**

* Updated `renovate.json` to add regex managers for Go version detection in `.github/workflows/go.yml`, `.github/workflows/security.yml`, and the new `osv-scanner.toml`, ensuring Renovate can update Go versions in all relevant locations. [[1]](diffhunk://#diff-7b5c8955fc544a11b4b74eddb4115f9cc51c9cf162dbffa60d37eeed82a55a57L11-R25) [[2]](diffhunk://#diff-7b5c8955fc544a11b4b74eddb4115f9cc51c9cf162dbffa60d37eeed82a55a57R41-R51)
* Added a `packageRule` to group `golang-security` dependencies under `go-version-security` for streamlined Go version updates related to security.