### PR TITLE
rename golang to go and add optional quotes in renovate.json regex

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -11,9 +11,9 @@
         "/.github/workflows/go.yml/"
       ],
       "datasourceTemplate": "golang-version",
-      "depNameTemplate": "golang",
+      "depNameTemplate": "go",
       "matchStrings": [
-        "go-version: (?<currentValue>[0-9]*.[0-9]*.[0-9]*)"
+        "go-version: \"?(?<currentValue>[0-9]*.[0-9]*.[0-9]*)\"?"
       ]
     },
     {
@@ -22,9 +22,9 @@
         "/.github/workflows/security.yml/"
       ],
       "datasourceTemplate": "golang-version",
-      "depNameTemplate": "golang-security",
+      "depNameTemplate": "go-security",
       "matchStrings": [
-        "go-version-input: (?<currentValue>[0-9]*.[0-9]*.[0-9]*)"
+        "go-version-input: \"?(?<currentValue>[0-9]*.[0-9]*.[0-9]*)\"?"
       ]
     },
     {
@@ -33,9 +33,9 @@
         "/.github/workflows/release.yml/"
       ],
       "datasourceTemplate": "golang-version",
-      "depNameTemplate": "golang",
+      "depNameTemplate": "go",
       "matchStrings": [
-        "go-version: (?<currentValue>[0-9]*.[0-9]*.[0-9]*)"
+        "go-version: \"?(?<currentValue>[0-9]*.[0-9]*.[0-9]*)\"?"
       ]
     },
     {
@@ -44,7 +44,7 @@
         "/osv-scanner.toml/"
       ],
       "datasourceTemplate": "golang-version",
-      "depNameTemplate": "golang-security",
+      "depNameTemplate": "go-security",
       "matchStrings": [
         "GoVersionOverride = \"(?<currentValue>[0-9]*.[0-9]*.[0-9]*)\""
       ]
@@ -148,7 +148,7 @@
   "packageRules": [
     {
       "matchDepNames": [
-        "golang-security"
+        "go-security"
       ],
       "groupName": "go-version-security"
     },


### PR DESCRIPTION
This pull request updates the `renovate.json` configuration to standardize the naming conventions for Go-related dependencies and improve the matching of Go version strings in workflow files. The main changes are focused on aligning the dependency names with official naming and making the version matching more robust.

Dependency naming standardization:

* Changed `depNameTemplate` and `matchDepNames` from `golang`/`golang-security` to `go`/`go-security` throughout the configuration to align with official Go naming conventions. [[1]](diffhunk://#diff-7b5c8955fc544a11b4b74eddb4115f9cc51c9cf162dbffa60d37eeed82a55a57L14-R16) [[2]](diffhunk://#diff-7b5c8955fc544a11b4b74eddb4115f9cc51c9cf162dbffa60d37eeed82a55a57L25-R27) [[3]](diffhunk://#diff-7b5c8955fc544a11b4b74eddb4115f9cc51c9cf162dbffa60d37eeed82a55a57L36-R38) [[4]](diffhunk://#diff-7b5c8955fc544a11b4b74eddb4115f9cc51c9cf162dbffa60d37eeed82a55a57L47-R47) [[5]](diffhunk://#diff-7b5c8955fc544a11b4b74eddb4115f9cc51c9cf162dbffa60d37eeed82a55a57L151-R151)

Version string matching improvements:

* Updated the `matchStrings` regex patterns to allow for optional quotes around Go version numbers, making the matching more flexible for different YAML formatting styles. [[1]](diffhunk://#diff-7b5c8955fc544a11b4b74eddb4115f9cc51c9cf162dbffa60d37eeed82a55a57L14-R16) [[2]](diffhunk://#diff-7b5c8955fc544a11b4b74eddb4115f9cc51c9cf162dbffa60d37eeed82a55a57L25-R27) [[3]](diffhunk://#diff-7b5c8955fc544a11b4b74eddb4115f9cc51c9cf162dbffa60d37eeed82a55a57L36-R38)