### PR TITLE
use go fix

### DIFF
--- a/configure/generate.go
+++ b/configure/generate.go
@@ -61,17 +61,17 @@ func Generate(configure string, modules3rd []module3rd.Module3rd, dependencies [
 }
 
 func generateForModule3rd(modules3rd []module3rd.Module3rd) string {
-	result := ""
+	var result strings.Builder
 	for _, m := range modules3rd {
 		opt := "--add-module"
 		if m.Dynamic {
 			opt = "--add-dynamic-module"
 		}
 		if m.Form == "local" {
-			result += fmt.Sprintf("%s=%s \\\n", opt, m.URL)
+			result.WriteString(fmt.Sprintf("%s=%s \\\n", opt, m.URL))
 		} else {
-			result += fmt.Sprintf("%s=../%s \\\n", opt, m.Name)
+			result.WriteString(fmt.Sprintf("%s=../%s \\\n", opt, m.Name))
 		}
 	}
-	return result
+	return result.String()
 }

--- a/configure/normalize.go
+++ b/configure/normalize.go
@@ -37,7 +37,7 @@ func Normalize(configure string) (string, string) {
 }
 
 func normalizeAddModulePaths(path, rootDir string, dynamic bool) string {
-	var result string
+	var result strings.Builder
 	if len(path) == 0 {
 		return path
 	}
@@ -51,11 +51,11 @@ func normalizeAddModulePaths(path, rootDir string, dynamic bool) string {
 
 	for _, modulePath := range modulePaths {
 		if strings.HasPrefix(modulePath, "/") {
-			result += opt + "=" + modulePath + " \\\n"
+			result.WriteString(opt + "=" + modulePath + " \\\n")
 		} else {
-			result += opt + "=" + rootDir + "/" + modulePath + " \\\n"
+			result.WriteString(opt + "=" + rootDir + "/" + modulePath + " \\\n")
 		}
 	}
 
-	return result
+	return result.String()
 }


### PR DESCRIPTION
This pull request refactors string concatenation logic in the `generateForModule3rd` and `normalizeAddModulePaths` functions to use a `strings.Builder` for improved performance and code clarity.

String concatenation improvements:

* Replaced repeated string concatenation with a `strings.Builder` in `generateForModule3rd` in `configure/generate.go`, enhancing efficiency when building large strings.
* Updated `normalizeAddModulePaths` in `configure/normalize.go` to use a `strings.Builder` instead of direct string concatenation, which improves performance and readability. [[1]](diffhunk://#diff-5cd895d47ad1a3025fb370d0753d85ab0cfebaf6f0c50b31dab3c72292fa5d3fL40-R40) [[2]](diffhunk://#diff-5cd895d47ad1a3025fb370d0753d85ab0cfebaf6f0c50b31dab3c72292fa5d3fL54-R60)