### PR TITLE
use LTS for OpenSSL

### DIFF
--- a/builder/const.go
+++ b/builder/const.go
@@ -14,7 +14,7 @@ const (
 
 // openssl
 const (
-	OpenSSLVersion           = "4.0.0"
+	OpenSSLVersion           = "3.5.6"
 	OpenSSLDownloadURLPrefix = "https://github.com/openssl/openssl/releases/download"
 )
 

--- a/renovate.json
+++ b/renovate.json
@@ -154,6 +154,16 @@
       "groupName": "go-version-security"
     },
     {
+      "description": "OpenSSL LTS only. See https://openssl-library.org/roadmap/index.html",
+      "matchDatasources": [
+        "github-tags"
+      ],
+      "matchPackageNames": [
+        "openssl/openssl"
+      ],
+      "allowedVersions": "/^3\\.5\\.[0-9]+$/"
+    },
+    {
       "matchDatasources": [
         "github-tags"
       ],


### PR DESCRIPTION
This pull request updates the OpenSSL version used in the project and enforces stricter dependency management for OpenSSL updates. The changes ensure that only OpenSSL LTS (Long Term Support) versions in the 3.5.x series are used, improving security and stability.

Dependency version updates and management:

* Downgraded the `OpenSSLVersion` constant in `builder/const.go` from `4.0.0` to `3.5.6` to use the latest LTS version instead of a non-LTS release.
* Updated `renovate.json` to restrict allowed OpenSSL versions to the 3.5.x LTS series, preventing automatic upgrades to non-LTS or incompatible versions.