### PR TITLE
use stable version for LibreSSL

### DIFF
--- a/builder/const.go
+++ b/builder/const.go
@@ -20,7 +20,7 @@ const (
 
 // libressl
 const (
-	LibreSSLVersion           = "4.3.1"
+	LibreSSLVersion           = "4.2.1"
 	LibreSSLDownloadURLPrefix = "https://ftp.openbsd.org/pub/OpenBSD/LibreSSL"
 )
 

--- a/renovate.json
+++ b/renovate.json
@@ -111,6 +111,7 @@
     },
     {
       "customType": "regex",
+      "description": "LibreSSL tags include development releases. Confirm stable status on https://www.libressl.org/ before approving updates.",
       "managerFilePatterns": [
         "/builder/const.go/"
       ],
@@ -162,6 +163,16 @@
         "openssl/openssl"
       ],
       "allowedVersions": "/^3\\.5\\.[0-9]+$/"
+    },
+    {
+      "description": "Confirm that LibreSSL is stable before approving updates. See https://www.libressl.org/",
+      "matchDatasources": [
+        "github-tags"
+      ],
+      "matchPackageNames": [
+        "libressl/portable"
+      ],
+      "dependencyDashboardApproval": true
     },
     {
       "matchDatasources": [


### PR DESCRIPTION
This pull request makes targeted changes to improve how LibreSSL updates are managed in the project. The main focus is on ensuring that only stable versions of LibreSSL are approved and used, both by updating the version in the code and by adding safeguards and reminders in the dependency management configuration.

LibreSSL version management:

* Downgraded the `LibreSSLVersion` constant in `builder/const.go` from `4.3.1` to `4.2.1`, ensuring that the project uses a stable release.

Dependency update process improvements (in `renovate.json`):

* Added descriptions and reminders to confirm LibreSSL stability before approving updates, including a note to check https://www.libressl.org/ for release status.
* Introduced a new rule requiring manual approval for LibreSSL updates, enforcing stability checks for the `libressl/portable` package before updates are merged.