### PR TITLE
fix: download zlib from GitHub releases

### DIFF
--- a/builder/builder.go
+++ b/builder/builder.go
@@ -113,7 +113,7 @@ func (builder *Builder) DownloadURL() string {
 	case ComponentCustomSSL:
 		return builder.CustomURL
 	case ComponentZlib:
-		return fmt.Sprintf("%s/zlib-%s.tar.gz", ZlibDownloadURLPrefix, builder.Version)
+		return fmt.Sprintf("%s/v%s/zlib-%s.tar.gz", ZlibDownloadURLPrefix, builder.Version, builder.Version)
 	case ComponentOpenResty:
 		return fmt.Sprintf("%s/openresty-%s.tar.gz", OpenRestyDownloadURLPrefix, builder.Version)
 	case ComponentFreenginx:

--- a/builder/builder_test.go
+++ b/builder/builder_test.go
@@ -140,7 +140,7 @@ func TestDownloadURL(t *testing.T) {
 		},
 		{
 			got:  builders[ComponentZlib].DownloadURL(),
-			want: fmt.Sprintf("%s/zlib-%s.tar.gz", ZlibDownloadURLPrefix, ZlibVersion),
+			want: fmt.Sprintf("%s/v%s/zlib-%s.tar.gz", ZlibDownloadURLPrefix, ZlibVersion, ZlibVersion),
 		},
 		{
 			got:  builders[ComponentOpenResty].DownloadURL(),

--- a/builder/const.go
+++ b/builder/const.go
@@ -27,7 +27,7 @@ const (
 // zlib
 const (
 	ZlibVersion           = "1.3.2"
-	ZlibDownloadURLPrefix = "https://zlib.net"
+	ZlibDownloadURLPrefix = "https://github.com/madler/zlib/releases/download"
 )
 
 // openResty


### PR DESCRIPTION
Downloads from zlib.net often fail. Use the official GitHub release archive instead. The archive is identical to the one provided by zlib.net.